### PR TITLE
Move filters to output channel

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -16,11 +16,10 @@
  */
 package io.kroxylicious.proxy;
 
-import java.util.List;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.internal.FilterChainFactory;
 import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
 import io.kroxylicious.proxy.internal.filter.AdvertisedListenersFilter;
@@ -66,7 +65,7 @@ public final class KafkaProxy {
                 Boolean.getBoolean("useIoUring"),
                 false,
                 false,
-                () -> List.of(
+                () -> new KrpcFilter[]{
                         new ApiVersionsFilter(),
                         new AdvertisedListenersFilter(new AdvertisedListenersFilter.AddressMapping() {
                             @Override
@@ -82,7 +81,7 @@ public final class KafkaProxy {
                           // new ProduceRecordTransformationInterceptor(
                           // buffer -> ByteBuffer.wrap(new String(StandardCharsets.UTF_8.decode(buffer).array()).toLowerCase().getBytes(StandardCharsets.UTF_8))
                           // )
-                ))
+                })
                         .startup()
                         .block();
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/KafkaRequestDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/KafkaRequestDecoder.java
@@ -16,7 +16,6 @@
  */
 package io.kroxylicious.proxy.codec;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.common.message.AddOffsetsToTxnRequestData;
@@ -64,12 +63,11 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaRequestDecoder.class);
 
-    private final List<KrpcFilter> filters;
+    private final KrpcFilter[] filters;
 
     private final Map<Integer, Correlation> correlation;
 
-    public KafkaRequestDecoder(List<KrpcFilter> filters,
-                               Map<Integer, Correlation> correlation) {
+    public KafkaRequestDecoder(Map<Integer, Correlation> correlation, KrpcFilter... filters) {
         super();
         this.filters = filters;
         this.correlation = correlation;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterChainFactory.java
@@ -16,8 +16,6 @@
  */
 package io.kroxylicious.proxy.internal;
 
-import java.util.List;
-
 import io.kroxylicious.proxy.filter.KrpcFilter;
 
 /**
@@ -31,5 +29,5 @@ public interface FilterChainFactory {
      * Create a new chain of filter instances
      * @return the new chain.
      */
-    List<KrpcFilter> createFilters();
+    KrpcFilter[] createFilters();
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -16,7 +16,6 @@
  */
 package io.kroxylicious.proxy.internal;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -48,7 +47,7 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     private final Map<Integer, Correlation> correlation;
     private final boolean logNetwork;
     private final boolean logFrames;
-    private final List<KrpcFilter> filters;
+    private final KrpcFilter[] filters;
 
     private ChannelHandlerContext outboundCtx;
     private KafkaProxyBackendHandler backendHandler;
@@ -58,7 +57,7 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     public KafkaProxyFrontendHandler(String remoteHost,
                                      int remotePort,
                                      Map<Integer, Correlation> correlation,
-                                     List<KrpcFilter> filters,
+                                     KrpcFilter[] filters,
                                      boolean logNetwork,
                                      boolean logFrames) {
         this.remoteHost = remoteHost;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -68,8 +68,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         // The decoder, this only cares about the filters
         // because it needs to know whether to decode requests
         KafkaRequestDecoder decoder = new KafkaRequestDecoder(
-                filters,
-                correlation);
+                correlation, filters);
         pipeline.addLast("requestDecoder", decoder);
 
         pipeline.addLast("responseEncoder", new KafkaResponseEncoder());

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/codec/RequestDecoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/codec/RequestDecoderTest.java
@@ -48,7 +48,6 @@ class RequestDecoderTest extends AbstractCodecTest {
                 AbstractCodecTest::deserializeApiVersionsRequestUsingKafkaApis,
                 new KafkaRequestDecoder(
                         List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                        List.of(),
                         new HashMap<>()),
                 DecodedRequestFrame.class);
     }
@@ -72,7 +71,6 @@ class RequestDecoderTest extends AbstractCodecTest {
                                 return KrpcFilterState.FORWARD;
                             }
                         }),
-                        List.of(),
                         new HashMap<>()),
                 OpaqueRequestFrame.class);
     }
@@ -91,7 +89,6 @@ class RequestDecoderTest extends AbstractCodecTest {
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
                 List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                List.of(),
                 new HashMap<>()).decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
@@ -110,7 +107,6 @@ class RequestDecoderTest extends AbstractCodecTest {
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
                 List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                List.of(),
                 new HashMap<>()).decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
@@ -153,7 +149,6 @@ class RequestDecoderTest extends AbstractCodecTest {
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
                 List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                List.of(),
                 new HashMap<>()).decode(null, byteBuf, messages);
 
         assertEquals(List.of(DecodedRequestFrame.class, DecodedRequestFrame.class), messageClasses(messages));

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/codec/RequestDecoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/codec/RequestDecoderTest.java
@@ -47,8 +47,8 @@ class RequestDecoderTest extends AbstractCodecTest {
                 AbstractCodecTest::deserializeRequestHeaderUsingKafkaApis,
                 AbstractCodecTest::deserializeApiVersionsRequestUsingKafkaApis,
                 new KafkaRequestDecoder(
-                        List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                        new HashMap<>()),
+                        new HashMap<>(),
+                        (ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
                 DecodedRequestFrame.class);
     }
 
@@ -60,7 +60,8 @@ class RequestDecoderTest extends AbstractCodecTest {
                 AbstractCodecTest::exampleRequestHeader,
                 AbstractCodecTest::exampleApiVersionsRequest,
                 new KafkaRequestDecoder(
-                        List.of(new ApiVersionsRequestFilter() {
+                        new HashMap<>(),
+                        new ApiVersionsRequestFilter() {
                             @Override
                             public boolean shouldDeserializeRequest(ApiKeys apiKey, short apiVersion) {
                                 return false;
@@ -71,7 +72,6 @@ class RequestDecoderTest extends AbstractCodecTest {
                                 return KrpcFilterState.FORWARD;
                             }
                         }),
-                        new HashMap<>()),
                 OpaqueRequestFrame.class);
     }
 
@@ -88,8 +88,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                new HashMap<>()).decode(null, byteBuf, messages);
+                new HashMap<>(),
+                (ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD).decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
         assertEquals(0, byteBuf.readerIndex());
@@ -106,8 +106,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                new HashMap<>()).decode(null, byteBuf, messages);
+                new HashMap<>(),
+                (ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD).decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
         assertEquals(expectRead, byteBuf.readerIndex());
@@ -148,8 +148,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                List.of((ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD),
-                new HashMap<>()).decode(null, byteBuf, messages);
+                new HashMap<>(),
+                (ApiVersionsRequestFilter) (request, context) -> KrpcFilterState.FORWARD).decode(null, byteBuf, messages);
 
         assertEquals(List.of(DecodedRequestFrame.class, DecodedRequestFrame.class), messageClasses(messages));
         DecodedRequestFrame frame = (DecodedRequestFrame) messages.get(0);


### PR DESCRIPTION
Before this PR the "request filters" are on the downstream pipeline and the "response filters" are on the upstream channel pipeline. i.e. Both `SingleRequestFilterHandler` and `SingleResponseFilterHandler` were `InboundChannelHandler`. 

This PR move the "request filters" to the upstream channel pipeline, so that `SingleRequestFilterHandler` becomes an `OutboundChannelHandler`.

Having the ChannelHandlers in the same pipeline should ensure that they always run on the same thread (something which the current KrprFilter contract promises, but isn't guaranteed by Netty AFAIK). 

In a later PR I intend to rationalise things further, so that each `Filter` is owned by a single `ChannelHander`. This should make it much simpler to implement `KrpcFilterContext.forwardRequest`.