### PR TITLE
Change output dir for tests

### DIFF
--- a/krpc-code-gen/src/test/java/io/kroxylicious/krpccodegen/main/KrpcGeneratorTest.java
+++ b/krpc-code-gen/src/test/java/io/kroxylicious/krpccodegen/main/KrpcGeneratorTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 class KrpcGeneratorTest {
 
     private static final String MESSAGE_SPECS_PATH = "message-specs/common/message";
-    private static final String OUTPUT_DIR = "generated-test-sources/krpc";
+    private static final String OUTPUT_DIR = "krpc-test-sources/krpc";
     private static final String TEST_CLASSES_DIR = "test-classes";
 
     @Test


### PR DESCRIPTION
Using `generated-test-sources/` meant that when I did `Build > Rebuild` in IntelliJ I'd get compile errors on the "java" source code produced by one of the test templates (because it wasn't valid Java source code, because it's only a test template).