### PR TITLE
Fix DecodedFrame.toString

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/DecodedFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/DecodedFrame.java
@@ -120,7 +120,7 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
     @Override
     public String toString() {
         return getClass().getSimpleName() + "(" +
-                ApiKeys.forId(apiVersion) + "(" + apiVersion + ")v" + apiVersion +
+                apiKey() + "(" + apiVersion + ")v" + apiVersion +
                 ", header=" + header +
                 ", body=" + body +
                 ')';


### PR DESCRIPTION
Looking up the apiKey using the version results in some pretty confusing debugging.