### PR TITLE
Make Opaque(Request|Response)Frame.toString more useful

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/OpaqueFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/OpaqueFrame.java
@@ -34,8 +34,8 @@ public abstract class OpaqueFrame implements Frame {
      */
     private static final int FRAME_SIZE_LENGTH = Integer.BYTES;
 
-    private final int length;
-    private final ByteBuf buf;
+    protected final int length;
+    protected final ByteBuf buf;
 
     public OpaqueFrame(ByteBuf buf, int length) {
         this.length = length;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/OpaqueRequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/OpaqueRequestFrame.java
@@ -16,10 +16,32 @@
  */
 package io.kroxylicious.proxy.codec;
 
+import org.apache.kafka.common.protocol.ApiKeys;
+
 import io.netty.buffer.ByteBuf;
 
 public class OpaqueRequestFrame extends OpaqueFrame implements RequestFrame {
     public OpaqueRequestFrame(ByteBuf buf, int length) {
         super(buf, length);
+    }
+
+    @Override
+    public String toString() {
+        int index = buf.readerIndex();
+        try {
+            var apiId = buf.readShort();
+            // TODO handle unknown api key
+            ApiKeys apiKey = ApiKeys.forId(apiId);
+            short apiVersion = buf.readShort();
+            return getClass().getSimpleName() + "(" +
+                    "length=" + length +
+                    ", apiKey=" + apiKey +
+                    ", apiVersion=" + apiVersion +
+                    ", buf=" + buf +
+                    ')';
+        }
+        finally {
+            buf.readerIndex(index);
+        }
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/OpaqueResponseFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/codec/OpaqueResponseFrame.java
@@ -22,4 +22,20 @@ public class OpaqueResponseFrame extends OpaqueFrame implements ResponseFrame {
     public OpaqueResponseFrame(ByteBuf buf, int length) {
         super(buf, length);
     }
+
+    @Override
+    public String toString() {
+        int index = buf.readerIndex();
+        try {
+            var correlationId = buf.readInt();
+            return getClass().getSimpleName() + "(" +
+                    "length=" + length +
+                    ", correlationId=" + correlationId +
+                    ", buf=" + buf +
+                    ')';
+        }
+        finally {
+            buf.readerIndex(index);
+        }
+    }
 }


### PR DESCRIPTION
When debugging I found the Opqaue*Frame toString was a bit too, well, opaque. This change makes the `toString` much less efficient, but that shouldn't _normally_ matter (assuming we're careful with how we use it in log). 