### PR TITLE
Rename ProxyTest → KrpcFilterIntegrationTest

### DIFF
--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/KrpcFilterIntegrationTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/KrpcFilterIntegrationTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SystemTest
-public class ProxyTest {
+public class KrpcFilterIntegrationTest {
 
     private static final String TOPIC_1 = "my-test-topic";
     private static final String TOPIC_2 = "other-test-topic";
@@ -154,7 +154,7 @@ public class ProxyTest {
         FilterChainFactory filterChainFactory = () -> new KrpcFilter[]{
                 new ApiVersionsFilter(),
                 new BrokerAddressFilter(new FixedAddressMapping(proxyHost, proxyPort)),
-                new ProduceRequestTransformationFilter(ProxyTest::encode)
+                new ProduceRequestTransformationFilter(KrpcFilterIntegrationTest::encode)
         };
 
         var proxy = startProxy(proxyHost, proxyPort, brokerList,
@@ -226,7 +226,7 @@ public class ProxyTest {
         FilterChainFactory filterChainFactory = () -> new KrpcFilter[]{
                 new ApiVersionsFilter(),
                 new BrokerAddressFilter(new FixedAddressMapping(proxyHost, proxyPort)),
-                new FetchResponseTransformationFilter(ProxyTest::decode)
+                new FetchResponseTransformationFilter(KrpcFilterIntegrationTest::decode)
         };
 
         var proxy = startProxy(proxyHost, proxyPort, brokerList,
@@ -295,7 +295,7 @@ public class ProxyTest {
     private String startKafkaCluster() throws IOException {
         var kafkaCluster = new KafkaCluster()
                 .addBrokers(1)
-                .usingDirectory(Files.createTempDirectory(ProxyTest.class.getName()).toFile())
+                .usingDirectory(Files.createTempDirectory(KrpcFilterIntegrationTest.class.getName()).toFile())
                 // .withKafkaConfiguration()
                 .startup();
 


### PR DESCRIPTION
I think `ProxyTest` is actually an integration test for KRPC filters. 

I don't think it's really capable of testing all the envisaged proxy functionality. For example: I don't think we'd be able to test "net filters" (in the presence of TLS) in the same way, because to test with SNI we'd need the client connecting to the proxy to be using the right DNS name, which isn't something we can easily control using a Junit test. Such testing would not look anything like `ProxyTest`: We might be able to leverage testcontainers (and [Strimzi's API on top of that](https://github.com/strimzi/test-container)) with a suitably configured bridge network to provide the DNS resolution, but even that's a bit tricky because we'd need the client to resolve DNS from with a container in that network...