### PR TITLE
Netfilter

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>netty-transport-native-unix-common</artifactId>
             <version>${netty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-haproxy</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -96,7 +101,6 @@
             <artifactId>picocli</artifactId>
             <version>4.6.3</version>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -5,12 +5,15 @@
  */
 package io.kroxylicious.proxy;
 
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
+import io.kroxylicious.proxy.internal.filter.SimpleNetFilter;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -103,9 +106,11 @@ public final class KafkaProxy {
         LOGGER.info("Proxying local {} to remote {}",
                 proxyAddress(), brokerAddress());
 
-        KafkaProxyInitializer initializer = new KafkaProxyInitializer(brokerHost,
-                brokerPort,
-                filterChainFactory,
+        KafkaProxyInitializer initializer = new KafkaProxyInitializer(false,
+                Map.of(),
+                new SimpleNetFilter(brokerHost,
+                        brokerPort,
+                        filterChainFactory),
                 logNetwork,
                 logFrames);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
@@ -8,7 +8,7 @@ package io.kroxylicious.proxy.filter;
 import java.net.SocketAddress;
 
 /**
- * Abstracts some policy/logic for now an upstream connection for a given client connection
+ * Abstracts some policy/logic for how an upstream connection for a given client connection
  * is made.
  */
 public interface NetFilter {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.filter;
+
+import java.net.SocketAddress;
+
+/**
+ * Abstracts some policy/logic for now an upstream connection for a given client connection
+ * is made.
+ */
+public interface NetFilter {
+
+    /**
+     * Determine the upstream cluster to connect to based on the information
+     * provided by the given {@code context},
+     * by invoking {@link NetFilterContext#connect(String, int, KrpcFilter[])}.
+     * @param context The context.
+     */
+    void upstreamBroker(NetFilterContext context);
+
+    interface NetFilterContext {
+        /**
+         * @return The address of the client
+         * (possibly not the address of the remote TCP/TLS peer, if any intermediate L4 or
+         * L7 proxy is propagating client connection information).
+         * @see #srcAddress()
+         */
+        public String clientAddress();
+
+        public int clientPort();
+
+        /**
+         * @return The address of the remote peer, which may be a proxy or the ultimate client.
+         * @see #clientAddress()
+         */
+        public SocketAddress srcAddress();
+
+        /**
+         * The authorized id, or null if there is no authentication configured for this listener.
+         * @return
+         */
+        public String authorizedId();
+
+        /**
+         * @return The name of the client software, if known via ApiVersions request. Otherwise null.
+         */
+        public String clientSoftwareName();
+
+        /**
+         * @return The version of the client software, if known via ApiVersions request. Otherwise null.
+         */
+        public String clientSoftwareVersion();
+
+        /**
+         * @return The <a href="https://en.wikipedia.org/wiki/Server_Name_Indication">SNI</a>
+         * hostname which the client used during TLS handshake.
+         */
+        public String sniHostname();
+
+        /**
+         * Connect to the upstream broker at the given {@code host} and {@code port},
+         * using the given protocol filters
+         * @param host The host
+         * @param port The port
+         * @param filters The filters
+         */
+        public void connect(String host, int port, KrpcFilter[] filters);
+
+        // TODO add API for delayed responses
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.frame;
+
+/**
+ * Ancient versions of Kafka implemented SASL/GSSAPI by sending the token
+ * on the wire as length prefixed bytes (no Kafka protocol header).
+ * This frame represents those kinds of request.
+ *
+ * @see "org.apache.kafka.common.security.authenticator.SaslServerAuthenticator#handleKafkaRequest()"
+ */
+public class BareSaslRequest implements RequestFrame {
+
+    private final byte[] bytes;
+    private final boolean decodeResponse;
+
+    public BareSaslRequest(byte[] bytes, boolean decodeResponse) {
+        this.bytes = bytes;
+        this.decodeResponse = decodeResponse;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return bytes.length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        out.writeByteArray(bytes);
+    }
+
+    @Override
+    public int correlationId() {
+        return 0;
+    }
+
+    @Override
+    public boolean decodeResponse() {
+        return decodeResponse;
+    }
+
+    public byte[] bytes() {
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.frame;
+
+/**
+ * Ancient versions of Kafka implemented SASL/GSSAPI by sending the response
+ * on the wire as length prefixed bytes (no Kafka protocol header).
+ * This frame represents those kinds of response.
+ */
+public class BareSaslResponse implements ResponseFrame {
+
+    private final byte[] bytes;
+
+    public BareSaslResponse(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return bytes.length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        out.writeByteArray(bytes);
+    }
+
+    @Override
+    public int correlationId() {
+        return 0;
+    }
+
+    public byte[] bytes() {
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Sent as a Netty "User Event" by the {@link KafkaAuthnHandler}
+ * to handlers interested in the authenticated user.
+ */
+public class AuthenticationEvent {
+    private final String authorizationId;
+    private final Map<String, Object> negotiatedProperties;
+
+    public AuthenticationEvent(String authorizationId, Map<String, Object> negotiatedProperties) {
+        this.authorizationId = authorizationId;
+        this.negotiatedProperties = Collections.unmodifiableMap(negotiatedProperties);
+    }
+
+    /**
+     * The id that the user authorized with
+     */
+    public String authorizationId() {
+        return authorizationId;
+    }
+
+    /**
+     * Extra authorization state produced by
+     * the authentication process.
+     */
+    public Map<String, Object> negotiatedProperties() {
+        return negotiatedProperties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        AuthenticationEvent that = (AuthenticationEvent) o;
+        return Objects.equals(authorizationId(), that.authorizationId()) && Objects.equals(negotiatedProperties(), that.negotiatedProperties());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authorizationId(), negotiatedProperties());
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import org.apache.kafka.common.errors.IllegalSaslStateException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.authenticator.SaslInternalConfigs;
+import org.apache.kafka.common.security.plain.internals.PlainSaslServerProvider;
+import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+import org.apache.kafka.common.security.scram.internals.ScramSaslServerProvider;
+
+import io.kroxylicious.proxy.frame.BareSaslRequest;
+import io.kroxylicious.proxy.frame.BareSaslResponse;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * <p>A Netty handler that allows the proxy
+ * to perform the Kafka SASL authentication exchanges needed by
+ * a client connection, specifically {@code SaslHandshake},
+ * and {@code SaslsAuthenticate}.</p>
+ *
+ * <p>See the doc for {@link State} for a detailed state machine.</p>
+ *
+ * <p>Client software and authorization information thus obtained is propagated via
+ * user events upstream handlers, specifically {@link KafkaProxyFrontendHandler}, to use in
+ * deciding how the connection to an upstream connection should be made.</p>
+ *
+ * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=51809888">KIP-12: Kafka Sasl/Kerberos and SSL implementation</a>
+ * added support for Kerberos authentication"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-43%3A+Kafka+SASL+enhancements">KIP-43: Kafka SASL enhancements</a>
+ * added the SaslHandshake RPC in Kafka 0.10.0.0"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-84%3A+Support+SASL+SCRAM+mechanisms">KIP-84: Support SASLS SCRAM mechanisms</a>
+ * added support for the SCRAM-SHA-256 and SCRAM-SHA-512 mechanisms"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-152+-+Improve+diagnostics+for+SASL+authentication+failures">KIP-152: Improve diagnostics for SASL authentication failures</a>
+ * added support for the SaslAuthenticate RPC (previously the auth bytes were not encapsulated in a Kafka frame"
+ * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876">KIP-255: OAuth Authentication via SASL/OAUTHBEARER</a>
+ * added support for OAUTH authentication"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate">KIP-365: Allow SASL Connections to Periodically Re-Authenticate</a>
+ * added time-based reauthentication requirements for clients"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-684+-+Support+mutual+TLS+authentication+on+SASL_SSL+listeners">KIP-684: Support mTLS authentication on SASL_SSL listeners</a>
+ * added support for mutual TLS authentication even on SASL_SSL listeners (which was previously ignored)"
+ */
+public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
+
+    static {
+        PlainSaslServerProvider.initialize();
+        ScramSaslServerProvider.initialize();
+    }
+
+    /**
+     * Represents a state in the {@link KafkaAuthnHandler} state machine.
+     * <pre><code>
+     *                            START
+     *                              │
+     *       ╭────────────────┬─────┴───────╮───────────────╮
+     *       │                │             │               │
+     *       ↓                ↓             │               ↓
+     * API_VERSIONS ──→ SASL_HANDSHAKE_v0 ══╪══⇒ unframed_SASL_AUTHENTICATE
+     *   │      │                           │                     │
+     *   │      │             ╭─────────────╯                     │
+     *   │      │             ↓                                   │
+     *   │      ╰───→ SASL_HANDSHAKE_v1+ ──→ SASL_AUTHENTICATE    │
+     *   │                                         │              ↓
+     *   ╰─────────────────────────────────────────╰─────→ UPSTREAM_CONNECT
+     * </code></pre>
+     * <ul>
+     * <li>API_VERSIONS if optional within the Kafka protocol</li>
+     * <li>SASL authentication may or may not be in use</li>
+     * </ul>
+     */
+    enum State {
+        START,
+        API_VERSIONS,
+        SASL_HANDSHAKE_v0,
+        SASL_HANDSHAKE_v1_PLUS,
+        UNFRAMED_SASL_AUTHENTICATE,
+        FRAMED_SASL_AUTHENTICATE,
+        AUTHN_SUCCESS
+    }
+
+    public enum SaslMechanism {
+        PLAIN("PLAIN", null),
+        SCRAM_SHA_256("SCRAM-SHA-256",
+                ScramMechanism.SCRAM_SHA_256,
+                SaslInternalConfigs.CREDENTIAL_LIFETIME_MS_SASL_NEGOTIATED_PROPERTY_KEY),
+        SCRAM_SHA_512("SCRAM-SHA-512", ScramMechanism.SCRAM_SHA_512,
+                SaslInternalConfigs.CREDENTIAL_LIFETIME_MS_SASL_NEGOTIATED_PROPERTY_KEY);
+
+        // TODO support OAUTHBEARER, GSSAPI
+        private final String name;
+        private final ScramMechanism scramMechanism;
+        private final String[] negotiableProperties;
+
+        private SaslMechanism(String saslName, ScramMechanism scramMechanism,
+                              String... negotiableProperties) {
+            this.name = saslName;
+            this.scramMechanism = scramMechanism;
+            this.negotiableProperties = negotiableProperties;
+        }
+
+        public String mechanismName() {
+            return name;
+        }
+
+        static SaslMechanism fromMechanismName(String mechanismName) {
+            switch (mechanismName) {
+                case "PLAIN":
+                    return PLAIN;
+                case "SCRAM-SHA-256":
+                    return SCRAM_SHA_256;
+                case "SCRAM-SHA-512":
+                    return SCRAM_SHA_512;
+            }
+            throw new UnsupportedSaslMechanismException(mechanismName);
+        }
+
+        public ScramMechanism scramMechanism() {
+            return scramMechanism;
+        }
+
+        public String[] negotiableProperties() {
+            return negotiableProperties;
+        }
+    }
+
+    // TODO need some way to support SaslAuthenticate v0, which doesn't use Kafka protcol framing at all
+
+    private final List<String> enabledMechanisms;
+
+    @VisibleForTesting
+    SaslServer saslServer;
+
+    private final Map<String, AuthenticateCallbackHandler> mechanismHandlers;
+
+    private State lastSeen;
+
+    public KafkaAuthnHandler(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this(State.START, mechanismHandlers);
+    }
+
+    @VisibleForTesting
+    KafkaAuthnHandler(State init,
+                      Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this.lastSeen = init;
+        this.mechanismHandlers = mechanismHandlers.entrySet().stream().collect(Collectors.toMap(
+                e -> e.getKey().mechanismName(), Map.Entry::getValue));
+        this.enabledMechanisms = List.copyOf(this.mechanismHandlers.keySet());
+    }
+
+    IllegalStateException illegalTransition(State next) {
+        return new IllegalStateException("Illegal state transition from " + lastSeen + " to " + next);
+    }
+
+    void validateTransition(State next) {
+        State previous = lastSeen;
+        switch (next) {
+            case API_VERSIONS:
+                if (previous != State.START) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case SASL_HANDSHAKE_v0:
+            case SASL_HANDSHAKE_v1_PLUS:
+                if (previous != State.START
+                        && previous != State.API_VERSIONS) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case UNFRAMED_SASL_AUTHENTICATE:
+                if (previous != State.START
+                        && previous != State.SASL_HANDSHAKE_v0
+                        && previous != State.UNFRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case FRAMED_SASL_AUTHENTICATE:
+                if (previous != State.SASL_HANDSHAKE_v1_PLUS
+                        && previous != State.FRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case AUTHN_SUCCESS:
+                if (previous != State.FRAMED_SASL_AUTHENTICATE
+                        && previous != State.UNFRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            default:
+                throw illegalTransition(next);
+        }
+        lastSeen = next;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof BareSaslRequest) {
+            var bareSaslRequest = (BareSaslRequest) msg;
+            if (supportsSaslGssApi() && (lastSeen == State.START
+                    || lastSeen == State.API_VERSIONS)) {
+                ctx.writeAndFlush(new BareSaslResponse(doEvaluateResponse(ctx, bareSaslRequest.bytes())));
+            }
+            else if (lastSeen == State.SASL_HANDSHAKE_v0
+                    || lastSeen == State.UNFRAMED_SASL_AUTHENTICATE) {
+                validateTransition(State.UNFRAMED_SASL_AUTHENTICATE);
+                // delegate to the SASL code to read the bytes directly
+                ctx.writeAndFlush(new BareSaslResponse(doEvaluateResponse(ctx, bareSaslRequest.bytes())));
+            }
+            else {
+                throw new IllegalStateException("lastSeen: " + lastSeen);
+            }
+        }
+        else if (msg instanceof DecodedRequestFrame) {
+            DecodedRequestFrame<?> frame = (DecodedRequestFrame<?>) msg;
+            {
+                switch (frame.apiKey()) {
+                    case API_VERSIONS:
+                        validateTransition(State.API_VERSIONS);
+                        ctx.fireChannelRead(frame);
+                        return;
+                    case SASL_HANDSHAKE:
+                        validateTransition(frame.apiVersion() == 0 ? State.SASL_HANDSHAKE_v0 : State.SASL_HANDSHAKE_v1_PLUS);
+                        onSaslHandshakeRequest(ctx, (DecodedRequestFrame<SaslHandshakeRequestData>) frame);
+                        return;
+                    case SASL_AUTHENTICATE:
+                        validateTransition(State.FRAMED_SASL_AUTHENTICATE);
+                        onSaslAuthenticateRequest(ctx, (DecodedRequestFrame<SaslAuthenticateRequestData>) frame);
+                        return;
+                    default:
+                        if (lastSeen == State.AUTHN_SUCCESS) {
+                            ctx.fireChannelRead(msg);
+                        }
+                        else {
+                            ctx.writeAndFlush(
+                                    new DecodedResponseFrame<>(
+                                            frame.apiVersion(),
+                                            frame.correlationId(),
+                                            new ResponseHeaderData().setCorrelationId(frame.correlationId()),
+                                            errorResponse(frame, new IllegalSaslStateException("Nope"))
+                                    // TODO add support for session lifetime/reauth
+                                    ));
+                        }
+                }
+            }
+        }
+        else {
+            throw new IllegalStateException("Unexpected message " + msg.getClass());
+        }
+    }
+
+    private ApiMessage errorResponse(DecodedRequestFrame<?> frame, Throwable error) {
+        ApiMessage body;
+        switch (frame.apiKey()) {
+            case METADATA:
+                body = new MetadataRequest((MetadataRequestData) frame.body(), frame.apiVersion()).getErrorResponse(0, error).data();
+                break;
+            // TODO all the other cases!
+            default:
+                throw new IllegalStateException();
+        }
+        return body;
+    }
+
+    private void onSaslHandshakeRequest(ChannelHandlerContext ctx,
+                                        DecodedRequestFrame<SaslHandshakeRequestData> data)
+            throws SaslException {
+        String mechanism = data.body().mechanism();
+        Errors error;
+        if (lastSeen == State.AUTHN_SUCCESS) {
+            error = Errors.ILLEGAL_SASL_STATE;
+        }
+        else if (enabledMechanisms.contains(mechanism)) {
+            var cbh = mechanismHandlers.get(mechanism);
+            // TODO use SNI to supply the correct hostname
+            saslServer = Sasl.createSaslServer(mechanism, "kafka", null, null, cbh);
+            if (saslServer == null) {
+                throw new IllegalStateException("SASL mechanism had no providers: " + mechanism);
+            }
+            else {
+                error = Errors.NONE;
+            }
+        }
+        else {
+            error = Errors.UNSUPPORTED_SASL_MECHANISM;
+        }
+
+        ctx.writeAndFlush(new DecodedResponseFrame<>(
+                data.apiVersion(),
+                data.correlationId(),
+                new ResponseHeaderData().setCorrelationId(data.correlationId()),
+                new SaslHandshakeResponseData()
+                        .setMechanisms(enabledMechanisms)
+                        .setErrorCode(error.code())));
+
+    }
+
+    private void onSaslAuthenticateRequest(ChannelHandlerContext ctx,
+                                           DecodedRequestFrame<SaslAuthenticateRequestData> data) {
+        byte[] bytes = new byte[0];
+        Errors error;
+        String errorMessage;
+
+        try {
+            bytes = doEvaluateResponse(ctx, data.body().authBytes());
+            error = Errors.NONE;
+            errorMessage = null;
+        }
+        catch (SaslAuthenticationException e) {
+            error = Errors.SASL_AUTHENTICATION_FAILED;
+            errorMessage = e.getMessage();
+        }
+        catch (SaslException e) {
+            error = Errors.SASL_AUTHENTICATION_FAILED;
+            errorMessage = "An error occurred";
+        }
+
+        ctx.writeAndFlush(
+                new DecodedResponseFrame<>(
+                        data.apiVersion(),
+                        data.correlationId(),
+                        new ResponseHeaderData().setCorrelationId(data.correlationId()),
+                        new SaslAuthenticateResponseData()
+                                .setErrorCode(error.code())
+                                .setErrorMessage(errorMessage)
+                                .setAuthBytes(bytes)
+                // TODO add support for session lifetime
+                ));
+    }
+
+    private void onUnframedSaslAuthenticateRequest(ChannelHandlerContext ctx,
+                                                   byte[] authBytes) {
+        ctx.writeAndFlush(authBytes);
+    }
+
+    private boolean supportsSaslGssApi() {
+        return false;
+    }
+
+    private byte[] doEvaluateResponse(ChannelHandlerContext ctx,
+                                      byte[] authBytes)
+            throws SaslException {
+        byte[] bytes = saslServer.evaluateResponse(authBytes);
+
+        if (saslServer.isComplete()) {
+            validateTransition(State.AUTHN_SUCCESS);
+            String authorizationId = saslServer.getAuthorizationID();
+            String[] properties = SaslMechanism.fromMechanismName(saslServer.getMechanismName()).negotiableProperties();
+            Map<String, Object> negotiatedProperty = new HashMap<>((int) (properties.length * 4.0 / 3));
+            for (String property : properties) {
+                Object value = saslServer.getNegotiatedProperty(property);
+                if (value != null) {
+                    negotiatedProperty.put(property, value);
+                }
+            }
+            saslServer.dispose();
+            ctx.fireUserEventTriggered(new AuthenticationEvent(authorizationId,
+                    negotiatedProperty));
+
+        }
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -70,7 +70,7 @@ public class KafkaProxyFrontendHandler
     private boolean pendingFlushes;
 
     private final NetFilter filter;
-    private final MyDecodePredicate dp;
+    private final SaslDecodePredicate dp;
 
     private AuthenticationEvent authentication;
 
@@ -122,7 +122,7 @@ public class KafkaProxyFrontendHandler
     private HAProxyMessage haProxyMessage;
 
     KafkaProxyFrontendHandler(NetFilter filter,
-                              MyDecodePredicate dp,
+                              SaslDecodePredicate dp,
                               boolean logNetwork,
                               boolean logFrames) {
         this.filter = filter;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -5,11 +5,29 @@
  */
 package io.kroxylicious.proxy.internal;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.SocketAddress;
+import java.util.Arrays;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ApiVersionsResponseDataJsonConverter;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.codec.CorrelationManager;
+import io.kroxylicious.proxy.internal.codec.DecodePredicate;
 import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
 import io.netty.bootstrap.Bootstrap;
@@ -21,40 +39,144 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SniCompletionEvent;
 
-public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
+public class KafkaProxyFrontendHandler
+        extends ChannelInboundHandlerAdapter
+        implements NetFilter.NetFilterContext {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyFrontendHandler.class);
 
-    private final String remoteHost;
-    private final int remotePort;
-    private final CorrelationManager correlationManager;
+    /** Cache ApiVersions response which we use when returning ApiVersions ourselves */
+    private static final ApiVersionsResponseData API_VERSIONS_RESPONSE;
+    static {
+        var objectMapper = new ObjectMapper();
+        try (var parser = KafkaProxyFrontendHandler.class.getResourceAsStream("/ApiVersions-3.2.json")) {
+            API_VERSIONS_RESPONSE = ApiVersionsResponseDataJsonConverter.read(objectMapper.readTree(parser), (short) 3);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     private final boolean logNetwork;
     private final boolean logFrames;
-    private final KrpcFilter[] filters;
 
     private ChannelHandlerContext outboundCtx;
     private KafkaProxyBackendHandler backendHandler;
     private boolean pendingFlushes;
-    private ChannelHandlerContext blockedInboundCtx;
 
-    public KafkaProxyFrontendHandler(String remoteHost,
-                                     int remotePort,
-                                     CorrelationManager correlationManager,
-                                     KrpcFilter[] filters,
-                                     boolean logNetwork,
-                                     boolean logFrames) {
-        this.remoteHost = remoteHost;
-        this.remotePort = remotePort;
-        this.correlationManager = correlationManager;
+    private final NetFilter filter;
+    private final MyDecodePredicate dp;
+
+    private AuthenticationEvent authentication;
+
+    private String clientSoftwareName;
+    private String clientSoftwareVersion;
+    private String sniHostname;
+
+    private ChannelHandlerContext inboundCtx;
+    // The message buffered while we connect to the outbound cluster
+    // There can only be one such because auto read is disabled until outbound
+    // channel activation
+    private Object bufferedMsg;
+    // Flag if we receive a channelReadComplete() prior to outbound connection activation
+    // so we can perform the channelReadComplete()/outbound flush & auto_read
+    // once the outbound channel is active
+    private boolean pendingReadComplete = true;
+
+    /** The initial state */
+    @VisibleForTesting static final int ST_START = 0;
+    /** An HAProxy message has been received */
+    @VisibleForTesting static final int ST_HA_PROXY = 1;
+    /** A Kafka ApiVersions request has been received */
+    @VisibleForTesting static final int ST_API_VERSIONS = 2;
+    /** Some other Kafka request has been received and we're in the process of connecting to the outbound cluster */
+    @VisibleForTesting static final int ST_CONNECTING = 3;
+    /** The outbound connection is connected but not yet active */
+    @VisibleForTesting static final int ST_CONNECTED = 4;
+    /** The outbound connection is active */
+    @VisibleForTesting static final int ST_OUTBOUND_ACTIVE = 5;
+    /** The connection to the outbound cluster failed */
+    @VisibleForTesting static final int ST_FAILED = 6;
+
+    private String stateName() {
+        switch (state) {
+            case ST_START:
+                return "ST_START";
+            case ST_HA_PROXY:
+                return "ST_HA_PROXY";
+            case ST_API_VERSIONS:
+                return "ST_API_VERSIONS";
+            case ST_CONNECTING:
+                return "ST_CONNECTING";
+            case ST_CONNECTED:
+                return "ST_CONNECTED";
+            case ST_OUTBOUND_ACTIVE:
+                return "ST_ACTIVE";
+            case ST_FAILED:
+                return "ST_FAILED";
+            default:
+                throw new IllegalStateException(Integer.toString(state));
+        }
+    }
+
+    /**
+     * The current state.
+     * Transitions:
+     * <code><pre>
+     * ST_START ──→ ST_HA_PROXY ──→ ST_API_VERSIONS ─╭─→ ST_CONNECTING ──→ ST_CONNECTED
+     *     ╰─────────────╰────────────────╰──────────╯      ╰──→ ST_FAILED
+     * </pre></code>
+     * Unexpected state transitions and exceptions also cause a
+     * transition to {@link #ST_FAILED} (via {@link #illegalState(String)}}
+     */
+    private int state = ST_START;
+
+    private boolean isInboundBlocked = true;
+    private HAProxyMessage haProxyMessage;
+
+    KafkaProxyFrontendHandler(NetFilter filter,
+                              MyDecodePredicate dp,
+                              boolean logNetwork,
+                              boolean logFrames) {
+        this.filter = filter;
+        this.dp = dp;
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
-        this.filters = filters;
+    }
+
+    private IllegalStateException illegalState(String msg) {
+        String name = stateName();
+        state = ST_FAILED;
+        return new IllegalStateException((msg == null ? "" : msg + ", ") + "state=" + name);
+    }
+
+    @VisibleForTesting
+    int state() {
+        return state;
     }
 
     public void outboundChannelActive(ChannelHandlerContext ctx) {
+        if (state != ST_CONNECTED) {
+            throw illegalState(null);
+        }
+        LOGGER.trace("{}: outboundChannelActive", inboundCtx.channel().id());
         outboundCtx = ctx;
+        // connection is complete, so first forward the buffered message
+        forwardOutbound(ctx, bufferedMsg);
+        bufferedMsg = null; // don't pin in memory once we no longer need it
+        if (pendingReadComplete) {
+            pendingReadComplete = false;
+            channelReadComplete(ctx);
+        }
+        state = ST_OUTBOUND_ACTIVE;
+
+        var inboundChannel = this.inboundCtx.channel();
+        // once buffered message has been forwarded we enable auto-read to start accepting further messages
+        inboundChannel.config().setAutoRead(true);
     }
 
     @Override
@@ -67,28 +189,80 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) {
-        LOGGER.trace("Channel active {}", ctx);
-        final Channel inboundChannel = ctx.channel();
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (state == ST_OUTBOUND_ACTIVE) { // post-backend connection
+            forwardOutbound(ctx, msg);
+        }
+        else { // pre-backend connection
+            if (state == ST_START
+                    && msg instanceof HAProxyMessage) {
+                this.haProxyMessage = (HAProxyMessage) msg;
+                state = ST_HA_PROXY;
+            }
+            else if ((state == ST_START
+                    || state == ST_HA_PROXY)
+                    && msg instanceof DecodedRequestFrame
+                    && ((DecodedRequestFrame<?>) msg).apiKey() == ApiKeys.API_VERSIONS) {
+                // This handler can respond to ApiVersions itself
+                writeApiVersionsResponse(ctx, (DecodedRequestFrame<ApiVersionsRequestData>) msg);
+                // ctx.fireChannelRead(msg);
+                // Request to read the following request
+                ctx.channel().read();
+                state = ST_API_VERSIONS;
+            }
+            else if ((state == ST_START
+                    || state == ST_HA_PROXY
+                    || state == ST_API_VERSIONS)
+                    && msg instanceof RequestFrame) {
+                if (bufferedMsg != null) {
+                    // Single buffered message assertion failed
+                    throw illegalState("Already have buffered msg");
+                }
+                state = ST_CONNECTING;
+                // But for any other request we'll need a backend connection
+                // (for which we need to ask the filter which cluster to connect to
+                // and with what filters)
+                this.bufferedMsg = msg;
+                // TODO ensure that the filter makes exactly one upstream connection?
+                // Or not for the topic routing case
+
+                // Note filter.upstreamBroker will call back on the connect() method below
+                filter.upstreamBroker(this);
+            }
+            else {
+                throw illegalState("Unexpected channelRead() message of " + msg.getClass());
+            }
+        }
+    }
+
+    @Override
+    public void connect(String remoteHost, int remotePort, KrpcFilter[] filters) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("{}: Connecting to backend broker {}:{} using filters {}",
+                    inboundCtx.channel().id(), remoteHost, remotePort, Arrays.toString(filters));
+        }
+        var correlationManager = new CorrelationManager();
+
+        final Channel inboundChannel = inboundCtx.channel();
 
         // Start the upstream connection attempt.
         Bootstrap b = new Bootstrap();
-        backendHandler = new KafkaProxyBackendHandler(this, ctx);
+        backendHandler = new KafkaProxyBackendHandler(this, inboundCtx);
         b.group(inboundChannel.eventLoop())
-                .channel(ctx.channel().getClass())
+                .channel(inboundChannel.getClass())
                 .handler(backendHandler)
                 .option(ChannelOption.AUTO_READ, true)
                 .option(ChannelOption.TCP_NODELAY, true);
 
         LOGGER.trace("Connecting to outbound {}:{}", remoteHost, remotePort);
-        ChannelFuture connectFuture = b.connect(remoteHost, remotePort);
+        ChannelFuture connectFuture = getConnect(remoteHost, remotePort, b);
         Channel outboundChannel = connectFuture.channel();
         ChannelPipeline pipeline = outboundChannel.pipeline();
 
         if (logFrames) {
             pipeline.addFirst("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamFrameLogger"));
         }
-        addFiltersToPipeline(pipeline);
+        addFiltersToPipeline(filters, pipeline);
         pipeline.addFirst("responseDecoder", new KafkaResponseDecoder(correlationManager));
         pipeline.addFirst("requestEncoder", new KafkaRequestEncoder(correlationManager));
         if (logNetwork) {
@@ -97,11 +271,14 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
 
         connectFuture.addListener(future -> {
             if (future.isSuccess()) {
-                LOGGER.trace("Outbound connect complete ({}), register interest to read on inbound channel {}", outboundChannel.localAddress(), inboundChannel);
-                // connection complete start to read first data
-                inboundChannel.config().setAutoRead(true);
+                state = ST_CONNECTED;
+                LOGGER.trace("{}: Outbound connected", inboundCtx.channel().id());
+                // Now we know which filters are to be used we need to update the DecodePredicate
+                // so that the decoder starts decoding the messages that the filters want to intercept
+                dp.setDelegate(DecodePredicate.forFilters(filters));
             }
             else {
+                state = ST_FAILED;
                 // Close the connection if the connection attempt has failed.
                 LOGGER.trace("Outbound connect error, closing inbound channel", future.cause());
                 inboundChannel.close();
@@ -109,22 +286,26 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
         });
     }
 
-    private void addFiltersToPipeline(ChannelPipeline pipeline) {
+    @VisibleForTesting ChannelFuture getConnect(String remoteHost, int remotePort, Bootstrap b) {
+        return b.connect(remoteHost, remotePort);
+    }
+
+    private void addFiltersToPipeline(KrpcFilter[] filters, ChannelPipeline pipeline) {
         for (var filter : filters) {
             pipeline.addFirst(filter.toString(), new FilterHandler(filter, 20000));
         }
     }
 
-    @Override
-    public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-        LOGGER.trace("Completed read on inbound channel: {}", msg);
+    public void forwardOutbound(final ChannelHandlerContext ctx, Object msg) {
         if (outboundCtx == null) {
-            LOGGER.trace("Outbound is not active");
+            LOGGER.trace("READ on inbound {} ignored because outbound is not active (msg: {})",
+                    ctx.channel(), msg);
             return;
         }
         final Channel outboundChannel = outboundCtx.channel();
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Outbound writable: {}", outboundChannel.isWritable());
+            LOGGER.trace("READ on inbound {} outbound {} (outbound.isWritable: {}, msg: {})",
+                    ctx.channel(), outboundChannel, outboundChannel.isWritable(), msg);
             LOGGER.trace("Outbound bytesBeforeUnwritable: {}", outboundChannel.bytesBeforeUnwritable());
             LOGGER.trace("Outbound config: {}", outboundChannel.config());
             LOGGER.trace("Outbound is active, writing and flushing {}", msg);
@@ -137,37 +318,65 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
             outboundChannel.writeAndFlush(msg, outboundCtx.voidPromise());
             pendingFlushes = false;
         }
+        LOGGER.trace("/READ");
+    }
+
+    /**
+     * Sends an ApiVersions response from this handler to the client
+     * (i.e. prior to having backend connection)
+     */
+    private void writeApiVersionsResponse(ChannelHandlerContext ctx, DecodedRequestFrame<ApiVersionsRequestData> frame) {
+        // TODO check the format of the strings using a regex
+        this.clientSoftwareName = frame.body().clientSoftwareName();
+        this.clientSoftwareVersion = frame.body().clientSoftwareVersion();
+
+        short apiVersion = frame.apiVersion();
+        int correlationId = frame.correlationId();
+        ResponseHeaderData header = new ResponseHeaderData()
+                .setCorrelationId(correlationId);
+        LOGGER.debug("{}: Writing ApiVersions response", ctx.channel());
+        ctx.writeAndFlush(new DecodedResponseFrame<>(
+                apiVersion, correlationId, header, API_VERSIONS_RESPONSE));
     }
 
     public void outboundWritabilityChanged(ChannelHandlerContext outboundCtx) {
-        assert this.outboundCtx == outboundCtx;
-        final ChannelHandlerContext inboundCtx = blockedInboundCtx;
-        if (inboundCtx != null && outboundCtx.channel().isWritable()) {
-            blockedInboundCtx = null;
+        if (this.outboundCtx != outboundCtx) {
+            throw illegalState("Mismatching outboundCtx");
+        }
+        if (isInboundBlocked && outboundCtx.channel().isWritable()) {
+            isInboundBlocked = false;
             inboundCtx.channel().config().setAutoRead(true);
         }
     }
 
     @Override
-    public void channelReadComplete(final ChannelHandlerContext ctx) throws Exception {
+    public void channelReadComplete(final ChannelHandlerContext ctx) {
         if (outboundCtx == null) {
-            LOGGER.trace("Outbound is not active");
+            LOGGER.trace("READ_COMPLETE on inbound {}, ignored because outbound is not active",
+                    ctx.channel());
+            pendingReadComplete = true;
             return;
         }
         final Channel outboundChannel = outboundCtx.channel();
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("READ_COMPLETE on inbound {} outbound {} (pendingFlushes: {}, isInboundBlocked: {}, output.isWritable: {})",
+                    ctx.channel(), outboundChannel,
+                    pendingFlushes, isInboundBlocked, outboundChannel.isWritable());
+        }
         if (pendingFlushes) {
             pendingFlushes = false;
             outboundChannel.flush();
         }
         if (!outboundChannel.isWritable()) {
             ctx.channel().config().setAutoRead(false);
-            this.blockedInboundCtx = ctx;
+            isInboundBlocked = true;
         }
 
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
+        LOGGER.trace("INACTIVE on inbound {}", ctx.channel());
         if (outboundCtx == null) {
             return;
         }
@@ -192,4 +401,78 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
         }
     }
 
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object event) throws Exception {
+        if (event instanceof SniCompletionEvent) {
+            SniCompletionEvent sniCompletionEvent = (SniCompletionEvent) event;
+            if (sniCompletionEvent.isSuccess()) {
+                this.sniHostname = sniCompletionEvent.hostname();
+            }
+            // TODO handle the failure case
+        }
+        else if (event instanceof AuthenticationEvent) {
+            this.authentication = (AuthenticationEvent) event;
+        }
+        super.userEventTriggered(ctx, event);
+    }
+
+    @Override
+    public String clientAddress() {
+        if (haProxyMessage != null) {
+            return haProxyMessage.sourceAddress();
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public int clientPort() {
+        if (haProxyMessage != null) {
+            return haProxyMessage.sourcePort();
+        }
+        else {
+            return -1;
+        }
+    }
+
+    @Override
+    public SocketAddress srcAddress() {
+        return inboundCtx.channel().remoteAddress();
+    }
+
+    @Override
+    public String authorizedId() {
+        return authentication != null ? authentication.authorizationId() : null;
+    }
+
+    @Override
+    public String clientSoftwareName() {
+        return clientSoftwareName;
+    }
+
+    @Override
+    public String clientSoftwareVersion() {
+        return clientSoftwareVersion;
+    }
+
+    @Override
+    public String sniHostname() {
+        return sniHostname;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        this.inboundCtx = ctx;
+        LOGGER.trace("{}: channelActive", inboundCtx.channel().id());
+        // Initially the channel is not auto reading, so read the first batch of requests
+        //assert !ctx.channel().config().isAutoRead();
+        ctx.channel().read();
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaProxyFrontendHandler{inbound = " + inboundCtx.channel() + ", state = " + stateName() + "}";
+    }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -60,7 +60,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
             pipeline.addLast("HAProxyMessageDecoder", new HAProxyMessageDecoder());
         }
 
-        var dp = new MyDecodePredicate(authnHandlers != null && !authnHandlers.isEmpty());
+        var dp = new SaslDecodePredicate(authnHandlers != null && !authnHandlers.isEmpty());
         // The decoder, this only cares about the filters
         // because it needs to know whether to decode requests
         KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MyDecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MyDecodePredicate.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.internal.codec.DecodePredicate;
+
+class MyDecodePredicate implements DecodePredicate {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MyDecodePredicate.class);
+
+    private final boolean handleSasl;
+    private DecodePredicate delegate = null;
+
+    public MyDecodePredicate(boolean handleSasl) {
+        this.handleSasl = handleSasl;
+    }
+
+    public void setDelegate(DecodePredicate delegate) {
+        LOGGER.debug("Setting delegate {}", delegate);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
+        boolean result;
+        if (apiKey == ApiKeys.API_VERSIONS) {
+            // TODO For now let's assume we need to always decode this, since the NetHandler
+            // currently does this. At some point we'll need a way to figure out the mutual intersection
+            // of api versions over all backend clusters plus the proxy itself.
+            result = true;
+        }
+        else if (apiKey == ApiKeys.SASL_HANDSHAKE
+                || apiKey == ApiKeys.SASL_AUTHENTICATE) {
+            result = handleSasl;
+        }
+        else {
+            result = delegate == null ? true : delegate.shouldDecodeRequest(apiKey, apiVersion);
+        }
+        // return result;
+        return true;
+    }
+
+    @Override
+    public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
+        // return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "MyDecodePredicate(" +
+                "handleSasl=" + handleSasl +
+                ", delegate=" + delegate +
+                ')';
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
@@ -11,14 +11,14 @@ import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.internal.codec.DecodePredicate;
 
-class MyDecodePredicate implements DecodePredicate {
+class SaslDecodePredicate implements DecodePredicate {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MyDecodePredicate.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaslDecodePredicate.class);
 
     private final boolean handleSasl;
     private DecodePredicate delegate = null;
 
-    public MyDecodePredicate(boolean handleSasl) {
+    public SaslDecodePredicate(boolean handleSasl) {
         this.handleSasl = handleSasl;
     }
 
@@ -43,14 +43,12 @@ class MyDecodePredicate implements DecodePredicate {
         else {
             result = delegate == null ? true : delegate.shouldDecodeRequest(apiKey, apiVersion);
         }
-        // return result;
-        return true;
+        return result;
     }
 
     @Override
     public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
-        // return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
-        return true;
+        return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/DecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/DecodePredicate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.codec;
+
+import java.util.Arrays;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+/**
+ * Encapsulates decisions about whether requests and responses should be
+ * fully deserialized into POJOs, or passed through as byte buffers with
+ * minimal deserialization.
+ *
+ * The actual decision can depend on which filters are in use, which can depend on
+ * who the authorized user or, or which back-end cluster they're connected to.
+ */
+public interface DecodePredicate {
+    public static DecodePredicate forFilters(KrpcFilter... filters) {
+        return new DecodePredicate() {
+            @Override
+            public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
+                for (var filter : filters) {
+                    if (filter.shouldDeserializeResponse(apiKey, apiVersion)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
+                for (var filter : filters) {
+                    if (filter.shouldDeserializeRequest(apiKey, apiVersion)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return "DecodePredicate$forFilters{" + Arrays.toString(filters) + "}";
+            }
+        };
+    }
+
+    public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion);
+
+    public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion);
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
@@ -25,7 +25,7 @@ public abstract class KafkaMessageDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    protected synchronized void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+    public synchronized void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         while (in.readableBytes() > 4) {
             try {
                 int sof = in.readerIndex();

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -80,7 +80,6 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
             log().trace("{}: apiVersion: {}", ctx, apiVersion);
         }
         int correlationId = in.readInt();
-        System.err.printf("Req from client %s/%s correlationId=%s%n", apiKey, apiVersion, correlationId);
         LOGGER.debug("{}: {} downstream correlation id: {}", ctx, apiKey, correlationId);
 
         RequestHeaderData header = null;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
@@ -58,7 +58,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
         out.writeInt(upstreamCorrelationId);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: {} downstream correlation id {} assigned upstream correlation id: {}",
-                    ctx.channel(), ApiKeys.forId(apiKey), downstreamCorrelationId, upstreamCorrelationId);
+                    ctx, ApiKeys.forId(apiKey), downstreamCorrelationId, upstreamCorrelationId);
         }
         out.readerIndex(ri);
         out.writerIndex(wi);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
 import org.apache.kafka.common.message.StopReplicaRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
@@ -78,7 +79,7 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             throw new AssertionError("Missing correlation id " + upstreamCorrelationId);
         }
         else if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("{}: Recovered correlation {} for upstream correlation id {}", ctx.channel(), correlation, upstreamCorrelationId);
+            LOGGER.debug("{}: Recovered correlation {} for upstream correlation id {}", ctx, correlation, upstreamCorrelationId);
         }
         int correlationId = correlation.downstreamCorrelationId();
         in.writerIndex(ri);
@@ -179,6 +180,8 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
                 return new WriteTxnMarkersResponseData(accessor, apiVersion);
             case TXN_OFFSET_COMMIT: // ???
                 return new TxnOffsetCommitResponseData(accessor, apiVersion);
+            case SASL_AUTHENTICATE:
+                return new SaslAuthenticateRequestData(accessor, apiVersion);
             default:
                 throw new IllegalArgumentException("Unsupported API key " + apiKey);
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseEncoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseEncoder.java
@@ -8,10 +8,7 @@ package io.kroxylicious.proxy.internal.codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.ResponseFrame;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 
 public class KafkaResponseEncoder extends KafkaMessageEncoder<ResponseFrame> {
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseEncoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseEncoder.java
@@ -8,7 +8,10 @@ package io.kroxylicious.proxy.internal.codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.ResponseFrame;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 
 public class KafkaResponseEncoder extends KafkaMessageEncoder<ResponseFrame> {
 
@@ -18,4 +21,5 @@ public class KafkaResponseEncoder extends KafkaMessageEncoder<ResponseFrame> {
     protected Logger log() {
         return LOGGER;
     }
+
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/SimpleNetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/SimpleNetFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.filter;
+
+import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
+import io.kroxylicious.proxy.filter.NetFilter;
+
+/**
+ * Implementation of {@link NetFilter} that is able to connect to a
+ * single cluster, using a single, constant {@link FilterChainFactory}.
+ */
+public class SimpleNetFilter implements NetFilter {
+
+    private final String remoteHost;
+    private final int remotePort;
+    private final FilterChainFactory filterChainFactory;
+
+    public SimpleNetFilter(String remoteHost, int remotePort, FilterChainFactory filterChainFactory) {
+        this.remoteHost = remoteHost;
+        this.remotePort = remotePort;
+        this.filterChainFactory = filterChainFactory;
+    }
+
+    @Override
+    public void upstreamBroker(NetFilterContext context) {
+        context.connect(remoteHost, remotePort, filterChainFactory.createFilters());
+    }
+}

--- a/kroxylicious/src/main/resources/ApiVersions-3.2.json
+++ b/kroxylicious/src/main/resources/ApiVersions-3.2.json
@@ -1,0 +1,242 @@
+{
+  "errorCode" : 0,
+  "apiKeys" : [ {
+    "apiKey" : 0,
+    "minVersion" : 0,
+    "maxVersion" : 9
+  }, {
+    "apiKey" : 1,
+    "minVersion" : 0,
+    "maxVersion" : 13
+  }, {
+    "apiKey" : 2,
+    "minVersion" : 0,
+    "maxVersion" : 7
+  }, {
+    "apiKey" : 3,
+    "minVersion" : 0,
+    "maxVersion" : 12
+  }, {
+    "apiKey" : 4,
+    "minVersion" : 0,
+    "maxVersion" : 6
+  }, {
+    "apiKey" : 5,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 6,
+    "minVersion" : 0,
+    "maxVersion" : 7
+  }, {
+    "apiKey" : 7,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 8,
+    "minVersion" : 0,
+    "maxVersion" : 8
+  }, {
+    "apiKey" : 9,
+    "minVersion" : 0,
+    "maxVersion" : 8
+  }, {
+    "apiKey" : 10,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 11,
+    "minVersion" : 0,
+    "maxVersion" : 9
+  }, {
+    "apiKey" : 12,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 13,
+    "minVersion" : 0,
+    "maxVersion" : 5
+  }, {
+    "apiKey" : 14,
+    "minVersion" : 0,
+    "maxVersion" : 5
+  }, {
+    "apiKey" : 15,
+    "minVersion" : 0,
+    "maxVersion" : 5
+  }, {
+    "apiKey" : 16,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 17,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 18,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 19,
+    "minVersion" : 0,
+    "maxVersion" : 7
+  }, {
+    "apiKey" : 20,
+    "minVersion" : 0,
+    "maxVersion" : 6
+  }, {
+    "apiKey" : 21,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 22,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 23,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 24,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 25,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 26,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 27,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 28,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 29,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 30,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 31,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 32,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 33,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 34,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 35,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 36,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 37,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 38,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 39,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 40,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 41,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 42,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 43,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 44,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 45,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 46,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 47,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 48,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 49,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 50,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 51,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 56,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 57,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 60,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 61,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 65,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 66,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 67,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  } ],
+  "throttleTimeMs" : 0,
+  "finalizedFeaturesEpoch" : 0
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class FilterHandlerTest extends FilterHarness {
+public class FilterHandlerTest extends FilterHarness {
 
     @Test
     public void testForwardRequest() {

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.authenticator.CredentialCache;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandler;
+import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
+import org.apache.kafka.common.security.scram.internals.ScramMessages;
+import org.apache.kafka.common.security.scram.internals.ScramServerCallbackHandler;
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.frame.BareSaslRequest;
+import io.kroxylicious.proxy.frame.BareSaslResponse;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.codec.CorrelationManager;
+import io.kroxylicious.proxy.internal.future.PromiseImpl;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KafkaAuthnHandlerTest {
+
+    public static final String CLIENT_SOFTWARE_NAME = "my-test-client";
+    public static final String CLIENT_SOFTWARE_VERSION = "1.0.0";
+    EmbeddedChannel channel = new EmbeddedChannel();
+    private final CorrelationManager correlationManager = new CorrelationManager();
+    private int corrId = 0;
+    private UserEventCollector userEventCollector;
+    private KafkaAuthnHandler kafkaAuthnHandler;
+
+    private void buildChanneel(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        channel = new EmbeddedChannel();
+        kafkaAuthnHandler = new KafkaAuthnHandler(
+                KafkaAuthnHandler.State.START, mechanismHandlers);
+        channel.pipeline().addLast(kafkaAuthnHandler);
+        userEventCollector = new UserEventCollector();
+        channel.pipeline().addLast(userEventCollector);
+        // channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+        // @Override
+        // public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        // if (msg instanceof DecodedRequestFrame) {
+        // if (((DecodedRequestFrame<?>) msg).body() instanceof ApiVersionsRequestData) {
+        // ctx.writeAndFlush(new DecodedResponseFrame<>(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION,
+        // 1, null, new ApiVersionsResponseData()));
+        // } else {
+        // fail();
+        // }
+        // }
+        // else {
+        // fail();
+        // }
+        // }
+        // });
+    }
+
+    @AfterEach
+    public void after() {
+        channel.checkException();
+    }
+
+    public static List<Object[]> apiVersions() {
+        var result = new ArrayList<Object[]>();
+        for (short apiVersionsVersion = ApiVersionsRequestData.LOWEST_SUPPORTED_VERSION; apiVersionsVersion <= ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION; apiVersionsVersion++) {
+            for (short handshakeVersion = SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION; handshakeVersion <= SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION; handshakeVersion++) {
+                for (short authenticateVersion = SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION; authenticateVersion <= SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION; authenticateVersion++) {
+                    result.add(new Object[]{ apiVersionsVersion, handshakeVersion, authenticateVersion });
+                }
+            }
+        }
+        return result;
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSuccessfulSaslPlainAuth(
+                                            short apiVersionsVersion,
+                                            short saslHandshakeVersion,
+                                            short saslAuthenticateVersion) {
+
+        buildChanneel(Map.of(KafkaAuthnHandler.SaslMechanism.PLAIN, saslPlainCallbackHandler()));
+
+        // ApiVersions should propagate
+        ApiVersionsRequestData apiVersionsRequest = new ApiVersionsRequestData()
+                .setClientSoftwareName(CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(CLIENT_SOFTWARE_VERSION);
+        writeRequest(apiVersionsVersion, apiVersionsRequest);
+
+        var cse = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect DecodedRequestFrame");
+        assertInstanceOf(ApiVersionsRequestData.class, cse.body(),
+                "Expected ApiVersions request to be propagated to next handler");
+
+        // We don't expect an ApiVersions response, because there is no handler in the pipeline
+        // which will send one
+
+        // Other requests should be denied
+        MetadataRequestData metadataRequest1 = new MetadataRequestData();
+        metadataRequest1.topics().add(new MetadataRequestData.MetadataRequestTopic().setName("topic"));
+
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest1);
+        assertNull(channel.readInbound(),
+                "Non-ApiVersions equests should not propagate prior to successful authn");
+        MetadataResponseData metadataResponse1 = readResponse(MetadataResponseData.class);
+        assertEquals(Errors.ILLEGAL_SASL_STATE.code(), metadataResponse1.topics().iterator().next().errorCode());
+
+        SaslHandshakeRequestData handshakeRequest = new SaslHandshakeRequestData()
+                .setMechanism("PLAIN");
+        writeRequest(saslHandshakeVersion, handshakeRequest);
+        var handshakeResponseBody = readResponse(SaslHandshakeResponseData.class);
+        assertEquals(Errors.NONE.code(), handshakeResponseBody.errorCode());
+
+        if (saslHandshakeVersion == 0) {
+            var bare = new BareSaslRequest("fred\0fred\0foo".getBytes(StandardCharsets.UTF_8), true);
+            channel.writeInbound(bare);
+            BareSaslResponse response = assertInstanceOf(BareSaslResponse.class, channel.readOutbound());
+            assertEquals(0, response.bytes().length);
+        }
+        else {
+            SaslAuthenticateRequestData authenticateRequest = new SaslAuthenticateRequestData()
+                    .setAuthBytes("fred\0fred\0foo".getBytes(StandardCharsets.UTF_8));
+            writeRequest(saslAuthenticateVersion, authenticateRequest);
+            SaslAuthenticateResponseData saslAuthenticateResponseData = readResponse(SaslAuthenticateResponseData.class);
+            assertEquals(Errors.NONE.code(), saslAuthenticateResponseData.errorCode());
+        }
+
+        // SASL server should be complete
+        assertTrue(kafkaAuthnHandler.saslServer.isComplete());
+
+        // Event should be propagated
+        var ae = assertInstanceOf(AuthenticationEvent.class, userEventCollector.readUserEvent(),
+                "Expect authentication event");
+        assertEquals("fred", ae.authorizationId());
+        assertTrue(ae.negotiatedProperties().isEmpty());
+        assertNull(userEventCollector.readUserEvent(), "Expected a single authn event");
+
+        // Subsequent events should be passed upstream
+        MetadataRequestData metadataRequest = new MetadataRequestData();
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest);
+        var followingFrame = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect RPC following successful authentication to be propagated");
+        assertInstanceOf(MetadataRequestData.class, followingFrame.body());
+
+    }
+
+    private PlainServerCallbackHandler saslPlainCallbackHandler() {
+        PlainServerCallbackHandler plainServerCallbackHandler = new PlainServerCallbackHandler();
+        plainServerCallbackHandler.configure(Map.of(),
+                KafkaAuthnHandler.SaslMechanism.PLAIN.mechanismName(),
+                List.of(new AppConfigurationEntry(PlainLoginModule.class.getName(),
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                        Map.of("user_fred", "foo"))));
+        return plainServerCallbackHandler;
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSuccessfulSaslScramSha256Auth(
+                                                  short apiVersionsVersion,
+                                                  short saslHandshakeVersion,
+                                                  short saslAuthenticateVersion)
+            throws Exception {
+        successfulSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_256, apiVersionsVersion, saslHandshakeVersion, saslAuthenticateVersion);
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSuccessfulSaslScramSha512Auth(
+                                                  short apiVersionsVersion,
+                                                  short saslHandshakeVersion,
+                                                  short saslAuthenticateVersion)
+            throws Exception {
+        successfulSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_512, apiVersionsVersion, saslHandshakeVersion, saslAuthenticateVersion);
+    }
+
+    private void successfulSaslScramShaAuth(
+                                            KafkaAuthnHandler.SaslMechanism saslMechanism,
+                                            short apiVersionsVersion,
+                                            short saslHandshakeVersion,
+                                            short saslAuthenticateVersion)
+            throws Exception {
+
+        buildChanneel(Map.of(saslMechanism, saslScramShaCallbackHandler(saslMechanism)));
+
+        // ApiVersions should propagate
+        ApiVersionsRequestData apiVersionsRequest = new ApiVersionsRequestData()
+                .setClientSoftwareName(CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(CLIENT_SOFTWARE_VERSION);
+        writeRequest(apiVersionsVersion, apiVersionsRequest);
+
+        var cse = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect DecodedRequestFrame");
+        assertInstanceOf(ApiVersionsRequestData.class, cse.body(),
+                "Expected ApiVersions request to be propagated to next handler");
+
+        // We don't expect an ApiVersions response, because there is no handler in the pipeline
+        // which will send one
+
+        // Other requests should be denied
+        MetadataRequestData metadataRequest1 = new MetadataRequestData();
+        metadataRequest1.topics().add(new MetadataRequestData.MetadataRequestTopic().setName("topic"));
+
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest1);
+        assertNull(channel.readInbound(),
+                "Non-ApiVersions equests should not propagate prior to successful authn");
+        MetadataResponseData metadataResponse1 = readResponse(MetadataResponseData.class);
+        assertEquals(Errors.ILLEGAL_SASL_STATE.code(), metadataResponse1.topics().iterator().next().errorCode());
+
+        SaslHandshakeRequestData handshakeRequest = new SaslHandshakeRequestData()
+                .setMechanism(saslMechanism.mechanismName());
+        writeRequest(saslHandshakeVersion, handshakeRequest);
+        var handshakeResponseBody = readResponse(SaslHandshakeResponseData.class);
+        assertEquals(Errors.NONE.code(), handshakeResponseBody.errorCode());
+
+        ScramFormatter scramFormatter = new ScramFormatter(saslMechanism.scramMechanism());
+
+        // First authenticate
+        ScramMessages.ClientFirstMessage clientFirst = new ScramMessages.ClientFirstMessage("fred", scramFormatter.secureRandomString(), Map.of());
+        ScramMessages.ServerFirstMessage serverFirstMessage;
+        if (saslHandshakeVersion == 0) {
+            var bare = new BareSaslRequest(clientFirst.toBytes(), true);
+            channel.writeInbound(bare);
+            BareSaslResponse response = assertInstanceOf(BareSaslResponse.class, channel.readOutbound());
+            assertNotEquals(0, response.bytes().length);
+            serverFirstMessage = new ScramMessages.ServerFirstMessage(response.bytes());
+        }
+        else {
+            SaslAuthenticateRequestData authenticateRequest = new SaslAuthenticateRequestData()
+                    .setAuthBytes(clientFirst.toBytes());
+            writeRequest(saslAuthenticateVersion, authenticateRequest);
+            SaslAuthenticateResponseData saslAuthenticateResponseData = readResponse(SaslAuthenticateResponseData.class);
+            assertEquals(Errors.NONE.code(), saslAuthenticateResponseData.errorCode());
+            serverFirstMessage = new ScramMessages.ServerFirstMessage(saslAuthenticateResponseData.authBytes());
+        }
+
+        // Second authenticate
+        byte[] passwordBytes = ScramFormatter.normalize(new String("password"));
+        var saltedPassword = scramFormatter.hi(passwordBytes, serverFirstMessage.salt(), serverFirstMessage.iterations());
+        ScramMessages.ClientFinalMessage clientFinal = new ScramMessages.ClientFinalMessage("n,,".getBytes(StandardCharsets.UTF_8), serverFirstMessage.nonce());
+        byte[] clientProof = scramFormatter.clientProof(saltedPassword, clientFirst, serverFirstMessage, clientFinal);
+        clientFinal.proof(clientProof);
+
+        if (saslHandshakeVersion == 0) {
+            var bare = new BareSaslRequest(clientFinal.toBytes(), true);
+            channel.writeInbound(bare);
+            BareSaslResponse response = assertInstanceOf(BareSaslResponse.class, channel.readOutbound());
+            assertNotEquals(0, response.bytes().length);
+        }
+        else {
+            SaslAuthenticateRequestData authenticateRequest = new SaslAuthenticateRequestData()
+                    .setAuthBytes(clientFinal.toBytes());
+            writeRequest(saslAuthenticateVersion, authenticateRequest);
+            SaslAuthenticateResponseData saslAuthenticateResponseData = readResponse(SaslAuthenticateResponseData.class);
+            assertEquals(Errors.NONE.code(), saslAuthenticateResponseData.errorCode());
+        }
+
+        // TODO assertions on the final server response
+
+        // SASL server should be complete
+        assertTrue(kafkaAuthnHandler.saslServer.isComplete());
+
+        // Event should be propagated
+        var ae = assertInstanceOf(AuthenticationEvent.class, userEventCollector.readUserEvent(),
+                "Expect authentication event");
+        assertEquals("fred", ae.authorizationId());
+        assertTrue(ae.negotiatedProperties().isEmpty());
+        assertNull(userEventCollector.readUserEvent(), "Expected a single authn event");
+
+        // Subsequent events should be passed upstream
+        MetadataRequestData metadataRequest = new MetadataRequestData();
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest);
+        var followingFrame = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect RPC following successful authentication to be propagated");
+        assertInstanceOf(MetadataRequestData.class, followingFrame.body());
+
+    }
+
+    private ScramServerCallbackHandler saslScramShaCallbackHandler(KafkaAuthnHandler.SaslMechanism saslMechanism) {
+        CredentialCache.Cache<ScramCredential> credentialCache = new CredentialCache.Cache<>(ScramCredential.class);
+        ScramCredential credential;
+        try {
+            credential = new ScramFormatter(saslMechanism.scramMechanism()).generateCredential("password", 4096);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        credentialCache.put("fred", credential);
+        ScramServerCallbackHandler callbackHandler = new ScramServerCallbackHandler(credentialCache, new DelegationTokenCache(List.of(saslMechanism.mechanismName())));
+        callbackHandler.configure(null, saslMechanism.mechanismName(), null);
+        return callbackHandler;
+    }
+
+    private <T extends ApiMessage> T readResponse(Class<T> cls) {
+        DecodedResponseFrame<?> authenticateResponseFrame = assertInstanceOf(DecodedResponseFrame.class, channel.readOutbound());
+        return assertInstanceOf(cls, authenticateResponseFrame.body());
+    }
+
+    private void writeRequest(short apiVersion, ApiMessage body) {
+        var apiKey = ApiKeys.forId(body.apiKey());
+
+        int downstreamCorrelationId = corrId++;
+
+        short headerVersion = apiKey.requestHeaderVersion(apiVersion);
+        RequestHeaderData header = new RequestHeaderData()
+                .setRequestApiKey(apiKey.id)
+                .setRequestApiVersion(apiVersion)
+                .setClientId("client-id")
+                .setCorrelationId(downstreamCorrelationId);
+
+        correlationManager.putBrokerRequest(body.apiKey(), apiVersion, downstreamCorrelationId, true, new KrpcFilter() {
+            @Override
+            public void onRequest(DecodedRequestFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+
+            }
+
+            @Override
+            public void onResponse(DecodedResponseFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+
+            }
+
+            @Override
+            public boolean shouldDeserializeResponse(ApiKeys apiKey, short apiVersion) {
+                return true;
+            }
+        }, new PromiseImpl<>(), true);
+
+        channel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
+    }
+
+    // TODO check the unsuccessful authentication case
+    // TODO check the bad password case
+    // TODO check the scram sha mechanisms
+    // TODO check that unexpected state transitions are handled with disconnection
+    // TODO check that unknown read type (like ProxyDecodeEvent) propagate to upstream handlers
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -70,22 +70,6 @@ public class KafkaAuthnHandlerTest {
         channel.pipeline().addLast(kafkaAuthnHandler);
         userEventCollector = new UserEventCollector();
         channel.pipeline().addLast(userEventCollector);
-        // channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-        // @Override
-        // public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        // if (msg instanceof DecodedRequestFrame) {
-        // if (((DecodedRequestFrame<?>) msg).body() instanceof ApiVersionsRequestData) {
-        // ctx.writeAndFlush(new DecodedResponseFrame<>(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION,
-        // 1, null, new ApiVersionsResponseData()));
-        // } else {
-        // fail();
-        // }
-        // }
-        // else {
-        // fail();
-        // }
-        // }
-        // });
     }
 
     @AfterEach

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -116,7 +116,7 @@ class KafkaProxyFrontendHandlerTest {
                              boolean sendApiVersions,
                              boolean sendSasl) {
 
-        var dp = new MyDecodePredicate(saslOffloadConfigured);
+        var dp = new SaslDecodePredicate(saslOffloadConfigured);
         ArgumentCaptor<NetFilter.NetFilterContext> valueCapture = ArgumentCaptor.forClass(NetFilter.NetFilterContext.class);
         var filter = mock(NetFilter.class);
         doAnswer(i -> {

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.haproxy.HAProxyCommand;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
+import io.netty.handler.ssl.SniCompletionEvent;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class KafkaProxyFrontendHandlerTest {
+
+    EmbeddedChannel inboundChannel;
+    EmbeddedChannel outboundChannel;
+
+    int corrId = 0;
+
+    private void writeRequest(short apiVersion, ApiMessage body) {
+        var apiKey = ApiKeys.forId(body.apiKey());
+
+        int downstreamCorrelationId = corrId++;
+
+        short headerVersion = apiKey.requestHeaderVersion(apiVersion);
+        RequestHeaderData header = new RequestHeaderData()
+                .setRequestApiKey(apiKey.id)
+                .setRequestApiVersion(apiVersion)
+                .setClientId("client-id")
+                .setCorrelationId(downstreamCorrelationId);
+
+//        correlationManager.putBrokerRequest(body.apiKey(), apiVersion, downstreamCorrelationId, true, new KrpcFilter() {
+//            @Override
+//            public void onRequest(DecodedRequestFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+//
+//            }
+//
+//            @Override
+//            public void onResponse(DecodedResponseFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+//
+//            }
+//
+//            @Override
+//            public boolean shouldDeserializeResponse(ApiKeys apiKey, short apiVersion) {
+//                return true;
+//            }
+//        }, new PromiseImpl<>(), true);
+
+        inboundChannel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
+    }
+
+    @BeforeEach
+    public void buildChannel() {
+        inboundChannel = new EmbeddedChannel();
+        corrId = 0;
+    }
+
+    @AfterEach
+    public void closeChannel() {
+        inboundChannel.close();
+    }
+
+    public static List<Arguments> provideArgsForExpectedFlow() {
+        var result = new ArrayList<Arguments>();
+        boolean[] tf = {true, false};
+        for (boolean sslConfigured: tf) {
+            for (boolean haProxyConfigured: tf) {
+                for (boolean saslOffloadConfigured: tf) {
+                    for (boolean sendApiVersions : tf) {
+                        for (boolean sendSasl : tf) {
+                            result.add(Arguments.of(sslConfigured, haProxyConfigured, saslOffloadConfigured, sendApiVersions, sendSasl));
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArgsForExpectedFlow")
+    public void expectedFlow(boolean sslConfigured,
+                             boolean haProxyConfigured,
+                             boolean saslOffloadConfigured,
+                             boolean sendApiVersions,
+                             boolean sendSasl) {
+
+        var dp = new MyDecodePredicate(saslOffloadConfigured);
+        ArgumentCaptor<NetFilter.NetFilterContext> valueCapture = ArgumentCaptor.forClass(NetFilter.NetFilterContext.class);
+        var filter = mock(NetFilter.class);
+        doAnswer(i -> {
+            NetFilter.NetFilterContext ctx = i.getArgument(0);
+            ctx.connect("internal.example.org", 9092, new KrpcFilter[0]);
+            return null;
+        }).when(filter).upstreamBroker(valueCapture.capture());
+
+        var handler = new KafkaProxyFrontendHandler(filter, dp, false, false) {
+            @Override
+            ChannelFuture getConnect(String remoteHost, int remotePort, Bootstrap b) {
+                // This is ugly... basically the EmbeddedChannel doesn't seem to handle the case
+                // of a handler creating an outgoing connection and ends up
+                // trying to re-register the outbound channel => IllegalStateException
+                // So we override this method to short-circuit that
+                outboundChannel = new EmbeddedChannel();
+                return new DefaultChannelPromise(outboundChannel).setSuccess();
+            }
+        };
+        inboundChannel.pipeline().addLast(handler);
+        inboundChannel.pipeline().fireChannelActive();
+
+        assertEquals(KafkaProxyFrontendHandler.ST_START, handler.state());
+
+        if (sslConfigured) {
+            // Simulate the SSL handler
+            inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent("external.example.com"));
+        }
+
+        if (haProxyConfigured) {
+            // Simulate the HA proxy handler
+            inboundChannel.writeInbound(new HAProxyMessage(HAProxyProtocolVersion.V1,
+                    HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                    "1.2.3.4", "5.6.7.8", 65535, 9092));
+        }
+
+        if (saslOffloadConfigured) {
+            // Simulate the KafkaAuthnHandler having done SASL offload
+            inboundChannel.pipeline().fireUserEventTriggered(new AuthenticationEvent("alice", Map.of()));
+        }
+
+        if (sendApiVersions) {
+            // Simulate the client doing ApiVersions
+            writeRequest(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION, new ApiVersionsRequestData());
+            assertEquals(KafkaProxyFrontendHandler.ST_API_VERSIONS, handler.state());
+            verify(filter, never()).upstreamBroker(handler);
+        }
+
+        if (sendSasl) {
+            if (saslOffloadConfigured) {
+                // If the pipeline is configured for SASL offload (KafkaAuthnHandler)
+                // then we assume it DOESN'T propagate the SASL frames down the pipeline
+                // and therefore no backend connection happens
+                verify(filter, never()).upstreamBroker(handler);
+            } else {
+                // Simulate the client doing SaslHandshake and SaslAuthentication,
+                writeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new SaslHandshakeRequestData());
+
+                // these should cause connection to the backend cluster
+                handleConnect(filter, handler);
+                writeRequest(SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new SaslAuthenticateRequestData());
+            }
+        }
+
+
+        // Simulate a Metadata request
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, new MetadataRequestData());
+        if (sendSasl && !saslOffloadConfigured) {
+            handleConnect(filter, handler);
+        }
+    }
+
+    private void handleConnect(NetFilter filter, KafkaProxyFrontendHandler handler) {
+        verify(filter).upstreamBroker(handler);
+        assertEquals(KafkaProxyFrontendHandler.ST_CONNECTED, handler.state());
+        assertFalse(inboundChannel.config().isAutoRead(),
+                "Expect inbound to be unwritable until output active");
+        ChannelHandlerContext context = outboundChannel.pipeline().context(outboundChannel.pipeline().names().get(0));
+        handler.outboundChannelActive(context);
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/UserEventCollector.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/UserEventCollector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * A ChannelInboundHandlerAdapter which allows asserting which users events were fired
+ * both other prior handlers in a netty pipeline.
+ */
+public class UserEventCollector extends ChannelInboundHandlerAdapter {
+    List<Object> events = new ArrayList<>();
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        Objects.requireNonNull(evt);
+        events.add(evt);
+        super.userEventTriggered(ctx, evt);
+    }
+
+    public Object readUserEvent() {
+        return events.isEmpty() ? null : events.remove(0);
+    }
+
+    public List<Object> userEvents() {
+        return events;
+    }
+
+    public void clearUserEvents() {
+        events.clear();
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -24,7 +24,7 @@ import io.netty.buffer.Unpooled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class RequestDecoderTest extends AbstractCodecTest {
+public class RequestDecoderTest extends AbstractCodecTest {
 
     @ParameterizedTest
     @MethodSource("requestApiVersions")
@@ -37,7 +37,7 @@ class RequestDecoderTest extends AbstractCodecTest {
                         AbstractCodecTest::deserializeRequestHeaderUsingKafkaApis,
                         AbstractCodecTest::deserializeApiVersionsRequestUsingKafkaApis,
                         new KafkaRequestDecoder(
-                                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)),
+                                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request))),
                         DecodedRequestFrame.class,
                         (RequestHeaderData header) -> header),
                 "Unexpected correlation id");
@@ -51,7 +51,7 @@ class RequestDecoderTest extends AbstractCodecTest {
                         ApiKeys.API_VERSIONS::requestHeaderVersion,
                         AbstractCodecTest::exampleRequestHeader,
                         AbstractCodecTest::exampleApiVersionsRequest,
-                        new KafkaRequestDecoder(
+                        new KafkaRequestDecoder(DecodePredicate.forFilters(
                                 new ApiVersionsRequestFilter() {
                                     @Override
                                     public boolean shouldDeserializeRequest(ApiKeys apiKey, short apiVersion) {
@@ -62,7 +62,7 @@ class RequestDecoderTest extends AbstractCodecTest {
                                     public void onApiVersionsRequest(ApiVersionsRequestData request, KrpcFilterContext context) {
                                         context.forwardRequest(request);
                                     }
-                                }),
+                                })),
                         OpaqueRequestFrame.class),
                 "Unexpected correlation id");
     }
@@ -80,7 +80,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)).decode(null, byteBuf, messages);
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)))
+                        .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
         assertEquals(0, byteBuf.readerIndex());
@@ -97,7 +98,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)).decode(null, byteBuf, messages);
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)))
+                        .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
         assertEquals(expectRead, byteBuf.readerIndex());
@@ -138,7 +140,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)).decode(null, byteBuf, messages);
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)))
+                        .decode(null, byteBuf, messages);
 
         assertEquals(List.of(DecodedRequestFrame.class, DecodedRequestFrame.class), messageClasses(messages));
         DecodedRequestFrame frame = (DecodedRequestFrame) messages.get(0);

--- a/kroxylicious/src/test/resources/log4j2-test.properties
+++ b/kroxylicious/src/test/resources/log4j2-test.properties
@@ -9,42 +9,42 @@ name = Config
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{3.}:%L - %m%n
 
-rootLogger.level = WARN
+rootLogger.level = TRACE
 rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
-#logger.kproxy.name = io.kroxylicious.proxy
-#logger.kproxy.level = INFO
-#logger.kproxy.additivity = false
-#logger.kproxy.appenderRef.console.ref = STDOUT
+logger.kproxy.name = io.kroxylicious.proxy
+logger.kproxy.level = TRACE
+logger.kproxy.additivity = false
+logger.kproxy.appenderRef.console.ref = STDOUT
 #
-#logger.internal.name = io.kroxylicious.proxy.internal
-#logger.internal.level = DEBUG
-#logger.internal.additivity = false
-#logger.internal.appenderRef.console.ref = STDOUT
+logger.internal.name = io.kroxylicious.proxy.internal
+logger.internal.level = TRACE
+logger.internal.additivity = false
+logger.internal.appenderRef.console.ref = STDOUT
 #
-#logger.netty.name = io.netty
-#logger.netty.level = TRACE
-#logger.netty.additivity = false
-#logger.netty.appenderRef.console.ref = STDOUT
+logger.netty.name = io.netty
+logger.netty.level = TRACE
+logger.netty.additivity = false
+logger.netty.appenderRef.console.ref = STDOUT
 #
-#logger.broker.name = kafka
-#logger.broker.level = DEBUG
-#logger.broker.additivity = false
-#logger.broker.appenderRef.console.ref = STDOUT
+logger.broker.name = kafka
+logger.broker.level = WARN
+logger.broker.additivity = false
+logger.broker.appenderRef.console.ref = STDOUT
 #
-#logger.scl.name = state.change.logger
-#logger.scl.level = WARN
-#logger.scl.additivity = false
-#logger.scl.appenderRef.console.ref = STDOUT
+logger.scl.name = state.change.logger
+logger.scl.level = WARN
+logger.scl.additivity = false
+logger.scl.appenderRef.console.ref = STDOUT
 #
-#logger.kclients.name = org.apache.kafka
-#logger.kclients.level = DEBUG
-#logger.kclients.additivity = false
-#logger.kclients.appenderRef.console.ref = STDOUT
+logger.kclients.name = org.apache.kafka
+logger.kclients.level = WARN
+logger.kclients.additivity = false
+logger.kclients.appenderRef.console.ref = STDOUT
 #
 
 # The following emit WARN logging during the tests

--- a/kroxylicious/src/test/resources/log4j2-test.properties
+++ b/kroxylicious/src/test/resources/log4j2-test.properties
@@ -9,42 +9,42 @@ name = Config
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{3.}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
 
-rootLogger.level = TRACE
+rootLogger.level = WARN
 rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
-logger.kproxy.name = io.kroxylicious.proxy
-logger.kproxy.level = TRACE
-logger.kproxy.additivity = false
-logger.kproxy.appenderRef.console.ref = STDOUT
+#logger.kproxy.name = io.kroxylicious.proxy
+#logger.kproxy.level = INFO
+#logger.kproxy.additivity = false
+#logger.kproxy.appenderRef.console.ref = STDOUT
 #
-logger.internal.name = io.kroxylicious.proxy.internal
-logger.internal.level = TRACE
-logger.internal.additivity = false
-logger.internal.appenderRef.console.ref = STDOUT
+#logger.internal.name = io.kroxylicious.proxy.internal
+#logger.internal.level = DEBUG
+#logger.internal.additivity = false
+#logger.internal.appenderRef.console.ref = STDOUT
 #
-logger.netty.name = io.netty
-logger.netty.level = TRACE
-logger.netty.additivity = false
-logger.netty.appenderRef.console.ref = STDOUT
+#logger.netty.name = io.netty
+#logger.netty.level = TRACE
+#logger.netty.additivity = false
+#logger.netty.appenderRef.console.ref = STDOUT
 #
-logger.broker.name = kafka
-logger.broker.level = WARN
-logger.broker.additivity = false
-logger.broker.appenderRef.console.ref = STDOUT
+#logger.broker.name = kafka
+#logger.broker.level = DEBUG
+#logger.broker.additivity = false
+#logger.broker.appenderRef.console.ref = STDOUT
 #
-logger.scl.name = state.change.logger
-logger.scl.level = WARN
-logger.scl.additivity = false
-logger.scl.appenderRef.console.ref = STDOUT
+#logger.scl.name = state.change.logger
+#logger.scl.level = WARN
+#logger.scl.additivity = false
+#logger.scl.appenderRef.console.ref = STDOUT
 #
-logger.kclients.name = org.apache.kafka
-logger.kclients.level = WARN
-logger.kclients.additivity = false
-logger.kclients.appenderRef.console.ref = STDOUT
+#logger.kclients.name = org.apache.kafka
+#logger.kclients.level = DEBUG
+#logger.kclients.additivity = false
+#logger.kclients.appenderRef.console.ref = STDOUT
 #
 
 # The following emit WARN logging during the tests

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
         <java.version>11</java.version>
         <java.test.version>17</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <maven.compiler.testRelease>${java.test.version}</maven.compiler.testRelease>
         <maven.compiler.testSource>${java.test.version}</maven.compiler.testSource>
         <maven.compiler.testTarget>${java.test.version}</maven.compiler.testTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,10 @@
         <java.version>11</java.version>
         <java.test.version>17</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.release>${java.version}</maven.compiler.release>
-        <maven.compiler.testRelease>${java.test.version}</maven.compiler.testRelease>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.testSource>${java.test.version}</maven.compiler.testSource>
+        <maven.compiler.testTarget>${java.test.version}</maven.compiler.testTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -170,6 +172,12 @@
                     <version>3.10.1</version>
                     <configuration>
                         <parameters>true</parameters>
+                        <source>11</source>
+                        <target>11</target>
+<!--                        <release>11</release>-->
+                        <testSource>17</testSource>
+                        <testTarget>17</testTarget>
+<!--                        <testRelease>17</testRelease>-->
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
This *draft* PR is not yet in a working state, but should be advanced enough for some initial feedback. 

The basic moving parts here are as follows:
* A `PROXYHandler` for dealing with the HAProxy PROXY protocol "connection header", so that kproxy can make use of the client source address when fronted by HAProxy (this could be split into a separate PR).
* A `KafkaAuthnHandler` for performing SASL authentication offload (i.e. the proxy does the authn). This is reusing some of Kafka's own SASL code and I've implemented support for SASL/Plain and SASL/SCRAM-SHA-256 and SASL/SCRAM-SHA-512. We can add support for OAUTHBEARER (and even GSSAPI) at a later stage.
* The `NetHandler` support the `NetFilter` SPI, which provides an extension point for selecting which upstream cluster the client should be connected to, and with which `KrpcFilters`. The `NetFilter.NetFilterContext` provides information, such as sniHostname, or authorized id, to a `NetFilter` implementation which has been obtained from prior handlers in the pipeline (optionally any of Netty's own `SSLHandler` (for SNI host), `PROXYHandler` and `KafkaAuthnHandler`) via "user events"
* Using that info, the `NetFilter` implementation is expected to call `NetFilterContext.connect()` exactly once. In other words the incoming "messages" could traverse any one of the following paths, depending on how things are configured@
    ```
    ─╮─ SSLHandler ─╭─╮─ PROXYHandler ─╭─╮─ KafkaAuthnHandler ─╭─── NetHandler
     ╰──────────────╯ ╰────────────────╯ ╰─────────────────────╯ 
    ```
* The `SimpleNetFilter` replicates the same functionality we already had: Connecting to a single statically known cluster with a statically known chain of `KrpcFilters`.
* Obviously you could support a "gateway" proxy which connected to different clusters depending on SNI hostname and/or authorised id. It could also use a different filter chain based on these.
* Further applications would include tar pitting, and closing connections based on this information (this is why propagating source addresses it useful, since we could make those decisions in part based on client IP address)

---

Apart from the general untidiness plus whatever other comments you raise, the main problem yet to resolve is that (in a pipeline with just the `NetHandler`, no SSL, PROXY or authn offload):
1. a producer makes the ApiVersions request
2. the NetHandler returns the ApiVersions response
3. the producer makes the Metadata request
4. the NetHandler passes control to the SimpleNetFilter, which calls back on `NetHandler.connect`, we create a `KafkaProxyFrontendHandler` and add it to the pipeline, but it doesn't get registered or activated by Netty. We don't have a Context for it in order to do those things ourselves.
5. When we subsequently call `ctx.fireChannelRead(msg);` with the `MetadataRequestData` (in `NetHandler.channelRead`) the metadata request gets silently dropped.
6. The subsequent `InitProduerId` request from the Producer does make it to the broker and the response returned, but it now has the wrong sequence number and the Producer throws because it never saw a response to the `Metadata` request.