### PR TITLE
#74: Implement handler for SASL Authentication offload

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.frame;
+
+/**
+ * Ancient versions of Kafka implemented SASL/GSSAPI by sending the token
+ * on the wire as length prefixed bytes (no Kafka protocol header).
+ * This frame represents those kinds of request.
+ *
+ * @see "org.apache.kafka.common.security.authenticator.SaslServerAuthenticator#handleKafkaRequest()"
+ */
+public class BareSaslRequest implements RequestFrame {
+
+    private final byte[] bytes;
+    private final boolean decodeResponse;
+
+    public BareSaslRequest(byte[] bytes, boolean decodeResponse) {
+        this.bytes = bytes;
+        this.decodeResponse = decodeResponse;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return bytes.length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        out.writeByteArray(bytes);
+    }
+
+    @Override
+    public int correlationId() {
+        return 0;
+    }
+
+    @Override
+    public boolean decodeResponse() {
+        return decodeResponse;
+    }
+
+    public byte[] bytes() {
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.frame;
+
+/**
+ * Ancient versions of Kafka implemented SASL/GSSAPI by sending the response
+ * on the wire as length prefixed bytes (no Kafka protocol header).
+ * This frame represents those kinds of response.
+ */
+public class BareSaslResponse implements ResponseFrame {
+
+    private final byte[] bytes;
+
+    public BareSaslResponse(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return bytes.length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        out.writeByteArray(bytes);
+    }
+
+    @Override
+    public int correlationId() {
+        return 0;
+    }
+
+    public byte[] bytes() {
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Sent as a Netty "User Event" by the {@link KafkaAuthnHandler}
+ * to handlers interested in the authenticated user.
+ */
+public class AuthenticationEvent {
+    private final String authorizationId;
+    private final Map<String, Object> negotiatedProperties;
+
+    public AuthenticationEvent(String authorizationId, Map<String, Object> negotiatedProperties) {
+        this.authorizationId = authorizationId;
+        this.negotiatedProperties = Collections.unmodifiableMap(negotiatedProperties);
+    }
+
+    /**
+     * The id that the user authorized with
+     */
+    public String authorizationId() {
+        return authorizationId;
+    }
+
+    /**
+     * Extra authorization state produced by
+     * the authentication process.
+     */
+    public Map<String, Object> negotiatedProperties() {
+        return negotiatedProperties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        AuthenticationEvent that = (AuthenticationEvent) o;
+        return Objects.equals(authorizationId(), that.authorizationId()) && Objects.equals(negotiatedProperties(), that.negotiatedProperties());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authorizationId(), negotiatedProperties());
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import org.apache.kafka.common.errors.IllegalSaslStateException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.authenticator.SaslInternalConfigs;
+import org.apache.kafka.common.security.plain.internals.PlainSaslServerProvider;
+import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+import org.apache.kafka.common.security.scram.internals.ScramSaslServerProvider;
+
+import io.kroxylicious.proxy.frame.BareSaslRequest;
+import io.kroxylicious.proxy.frame.BareSaslResponse;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * <p>A Netty handler that allows the proxy
+ * to perform the Kafka SASL authentication exchanges needed by
+ * a client connection, specifically {@code SaslHandshake},
+ * and {@code SaslsAuthenticate}.</p>
+ *
+ * <p>See the doc for {@link State} for a detailed state machine.</p>
+ *
+ * <p>Client software and authorization information thus obtained is propagated via
+ * user events upstream handlers, specifically {@link KafkaProxyFrontendHandler}, to use in
+ * deciding how the connection to an upstream connection should be made.</p>
+ *
+ * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=51809888">KIP-12: Kafka Sasl/Kerberos and SSL implementation</a>
+ * added support for Kerberos authentication"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-43%3A+Kafka+SASL+enhancements">KIP-43: Kafka SASL enhancements</a>
+ * added the SaslHandshake RPC in Kafka 0.10.0.0"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-84%3A+Support+SASL+SCRAM+mechanisms">KIP-84: Support SASLS SCRAM mechanisms</a>
+ * added support for the SCRAM-SHA-256 and SCRAM-SHA-512 mechanisms"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-152+-+Improve+diagnostics+for+SASL+authentication+failures">KIP-152: Improve diagnostics for SASL authentication failures</a>
+ * added support for the SaslAuthenticate RPC (previously the auth bytes were not encapsulated in a Kafka frame"
+ * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876">KIP-255: OAuth Authentication via SASL/OAUTHBEARER</a>
+ * added support for OAUTH authentication"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate">KIP-365: Allow SASL Connections to Periodically Re-Authenticate</a>
+ * added time-based reauthentication requirements for clients"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-684+-+Support+mutual+TLS+authentication+on+SASL_SSL+listeners">KIP-684: Support mTLS authentication on SASL_SSL listeners</a>
+ * added support for mutual TLS authentication even on SASL_SSL listeners (which was previously ignored)"
+ */
+public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
+
+    static {
+        PlainSaslServerProvider.initialize();
+        ScramSaslServerProvider.initialize();
+    }
+
+    /**
+     * Represents a state in the {@link KafkaAuthnHandler} state machine.
+     * <pre><code>
+     *                            START
+     *                              │
+     *       ╭────────────────┬─────┴───────╮───────────────╮
+     *       │                │             │               │
+     *       ↓                ↓             │               ↓
+     * API_VERSIONS ──→ SASL_HANDSHAKE_v0 ══╪══⇒ unframed_SASL_AUTHENTICATE
+     *   │      │                           │                     │
+     *   │      │             ╭─────────────╯                     │
+     *   │      │             ↓                                   │
+     *   │      ╰───→ SASL_HANDSHAKE_v1+ ──→ SASL_AUTHENTICATE    │
+     *   │                                         │              ↓
+     *   ╰─────────────────────────────────────────╰─────→ UPSTREAM_CONNECT
+     * </code></pre>
+     * <ul>
+     * <li>API_VERSIONS if optional within the Kafka protocol</li>
+     * <li>SASL authentication may or may not be in use</li>
+     * </ul>
+     */
+    enum State {
+        START,
+        API_VERSIONS,
+        SASL_HANDSHAKE_v0,
+        SASL_HANDSHAKE_v1_PLUS,
+        UNFRAMED_SASL_AUTHENTICATE,
+        FRAMED_SASL_AUTHENTICATE,
+        AUTHN_SUCCESS
+    }
+
+    public enum SaslMechanism {
+        PLAIN("PLAIN", null),
+        SCRAM_SHA_256("SCRAM-SHA-256",
+                ScramMechanism.SCRAM_SHA_256,
+                SaslInternalConfigs.CREDENTIAL_LIFETIME_MS_SASL_NEGOTIATED_PROPERTY_KEY),
+        SCRAM_SHA_512("SCRAM-SHA-512", ScramMechanism.SCRAM_SHA_512,
+                SaslInternalConfigs.CREDENTIAL_LIFETIME_MS_SASL_NEGOTIATED_PROPERTY_KEY);
+
+        // TODO support OAUTHBEARER, GSSAPI
+        private final String name;
+        private final ScramMechanism scramMechanism;
+        private final String[] negotiableProperties;
+
+        private SaslMechanism(String saslName, ScramMechanism scramMechanism,
+                              String... negotiableProperties) {
+            this.name = saslName;
+            this.scramMechanism = scramMechanism;
+            this.negotiableProperties = negotiableProperties;
+        }
+
+        public String mechanismName() {
+            return name;
+        }
+
+        static SaslMechanism fromMechanismName(String mechanismName) {
+            switch (mechanismName) {
+                case "PLAIN":
+                    return PLAIN;
+                case "SCRAM-SHA-256":
+                    return SCRAM_SHA_256;
+                case "SCRAM-SHA-512":
+                    return SCRAM_SHA_512;
+            }
+            throw new UnsupportedSaslMechanismException(mechanismName);
+        }
+
+        public ScramMechanism scramMechanism() {
+            return scramMechanism;
+        }
+
+        public String[] negotiableProperties() {
+            return negotiableProperties;
+        }
+    }
+
+    // TODO need some way to support SaslAuthenticate v0, which doesn't use Kafka protcol framing at all
+
+    private final List<String> enabledMechanisms;
+
+    @VisibleForTesting
+    SaslServer saslServer;
+
+    private final Map<String, AuthenticateCallbackHandler> mechanismHandlers;
+
+    private State lastSeen;
+
+    public KafkaAuthnHandler(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this(State.START, mechanismHandlers);
+    }
+
+    @VisibleForTesting
+    KafkaAuthnHandler(State init,
+                      Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this.lastSeen = init;
+        this.mechanismHandlers = mechanismHandlers.entrySet().stream().collect(Collectors.toMap(
+                e -> e.getKey().mechanismName(), Map.Entry::getValue));
+        this.enabledMechanisms = List.copyOf(this.mechanismHandlers.keySet());
+    }
+
+    IllegalStateException illegalTransition(State next) {
+        return new IllegalStateException("Illegal state transition from " + lastSeen + " to " + next);
+    }
+
+    void validateTransition(State next) {
+        State previous = lastSeen;
+        switch (next) {
+            case API_VERSIONS:
+                if (previous != State.START) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case SASL_HANDSHAKE_v0:
+            case SASL_HANDSHAKE_v1_PLUS:
+                if (previous != State.START
+                        && previous != State.API_VERSIONS) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case UNFRAMED_SASL_AUTHENTICATE:
+                if (previous != State.START
+                        && previous != State.SASL_HANDSHAKE_v0
+                        && previous != State.UNFRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case FRAMED_SASL_AUTHENTICATE:
+                if (previous != State.SASL_HANDSHAKE_v1_PLUS
+                        && previous != State.FRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case AUTHN_SUCCESS:
+                if (previous != State.FRAMED_SASL_AUTHENTICATE
+                        && previous != State.UNFRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            default:
+                throw illegalTransition(next);
+        }
+        lastSeen = next;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof BareSaslRequest) {
+            var bareSaslRequest = (BareSaslRequest) msg;
+            if (supportsSaslGssApi() && (lastSeen == State.START
+                    || lastSeen == State.API_VERSIONS)) {
+                ctx.writeAndFlush(new BareSaslResponse(doEvaluateResponse(ctx, bareSaslRequest.bytes())));
+            }
+            else if (lastSeen == State.SASL_HANDSHAKE_v0
+                    || lastSeen == State.UNFRAMED_SASL_AUTHENTICATE) {
+                validateTransition(State.UNFRAMED_SASL_AUTHENTICATE);
+                // delegate to the SASL code to read the bytes directly
+                ctx.writeAndFlush(new BareSaslResponse(doEvaluateResponse(ctx, bareSaslRequest.bytes())));
+            }
+            else {
+                throw new IllegalStateException("lastSeen: " + lastSeen);
+            }
+        }
+        else if (msg instanceof DecodedRequestFrame) {
+            DecodedRequestFrame<?> frame = (DecodedRequestFrame<?>) msg;
+            {
+                switch (frame.apiKey()) {
+                    case API_VERSIONS:
+                        validateTransition(State.API_VERSIONS);
+                        ctx.fireChannelRead(frame);
+                        return;
+                    case SASL_HANDSHAKE:
+                        validateTransition(frame.apiVersion() == 0 ? State.SASL_HANDSHAKE_v0 : State.SASL_HANDSHAKE_v1_PLUS);
+                        onSaslHandshakeRequest(ctx, (DecodedRequestFrame<SaslHandshakeRequestData>) frame);
+                        return;
+                    case SASL_AUTHENTICATE:
+                        validateTransition(State.FRAMED_SASL_AUTHENTICATE);
+                        onSaslAuthenticateRequest(ctx, (DecodedRequestFrame<SaslAuthenticateRequestData>) frame);
+                        return;
+                    default:
+                        if (lastSeen == State.AUTHN_SUCCESS) {
+                            ctx.fireChannelRead(msg);
+                        }
+                        else {
+                            ctx.writeAndFlush(
+                                    new DecodedResponseFrame<>(
+                                            frame.apiVersion(),
+                                            frame.correlationId(),
+                                            new ResponseHeaderData().setCorrelationId(frame.correlationId()),
+                                            errorResponse(frame, new IllegalSaslStateException("Nope"))
+                                    // TODO add support for session lifetime/reauth
+                                    ));
+                        }
+                }
+            }
+        }
+        else {
+            throw new IllegalStateException("Unexpected message " + msg.getClass());
+        }
+    }
+
+    private ApiMessage errorResponse(DecodedRequestFrame<?> frame, Throwable error) {
+        ApiMessage body;
+        switch (frame.apiKey()) {
+            case METADATA:
+                body = new MetadataRequest((MetadataRequestData) frame.body(), frame.apiVersion()).getErrorResponse(0, error).data();
+                break;
+            // TODO all the other cases!
+            default:
+                throw new IllegalStateException();
+        }
+        return body;
+    }
+
+    private void onSaslHandshakeRequest(ChannelHandlerContext ctx,
+                                        DecodedRequestFrame<SaslHandshakeRequestData> data)
+            throws SaslException {
+        String mechanism = data.body().mechanism();
+        Errors error;
+        if (lastSeen == State.AUTHN_SUCCESS) {
+            error = Errors.ILLEGAL_SASL_STATE;
+        }
+        else if (enabledMechanisms.contains(mechanism)) {
+            var cbh = mechanismHandlers.get(mechanism);
+            // TODO use SNI to supply the correct hostname
+            saslServer = Sasl.createSaslServer(mechanism, "kafka", null, null, cbh);
+            if (saslServer == null) {
+                throw new IllegalStateException("SASL mechanism had no providers: " + mechanism);
+            }
+            else {
+                error = Errors.NONE;
+            }
+        }
+        else {
+            error = Errors.UNSUPPORTED_SASL_MECHANISM;
+        }
+
+        ctx.writeAndFlush(new DecodedResponseFrame<>(
+                data.apiVersion(),
+                data.correlationId(),
+                new ResponseHeaderData().setCorrelationId(data.correlationId()),
+                new SaslHandshakeResponseData()
+                        .setMechanisms(enabledMechanisms)
+                        .setErrorCode(error.code())));
+
+    }
+
+    private void onSaslAuthenticateRequest(ChannelHandlerContext ctx,
+                                           DecodedRequestFrame<SaslAuthenticateRequestData> data) {
+        byte[] bytes = new byte[0];
+        Errors error;
+        String errorMessage;
+
+        try {
+            bytes = doEvaluateResponse(ctx, data.body().authBytes());
+            error = Errors.NONE;
+            errorMessage = null;
+        }
+        catch (SaslAuthenticationException e) {
+            error = Errors.SASL_AUTHENTICATION_FAILED;
+            errorMessage = e.getMessage();
+        }
+        catch (SaslException e) {
+            error = Errors.SASL_AUTHENTICATION_FAILED;
+            errorMessage = "An error occurred";
+        }
+
+        ctx.writeAndFlush(
+                new DecodedResponseFrame<>(
+                        data.apiVersion(),
+                        data.correlationId(),
+                        new ResponseHeaderData().setCorrelationId(data.correlationId()),
+                        new SaslAuthenticateResponseData()
+                                .setErrorCode(error.code())
+                                .setErrorMessage(errorMessage)
+                                .setAuthBytes(bytes)
+                // TODO add support for session lifetime
+                ));
+    }
+
+    private void onUnframedSaslAuthenticateRequest(ChannelHandlerContext ctx,
+                                                   byte[] authBytes) {
+        ctx.writeAndFlush(authBytes);
+    }
+
+    private boolean supportsSaslGssApi() {
+        return false;
+    }
+
+    private byte[] doEvaluateResponse(ChannelHandlerContext ctx,
+                                      byte[] authBytes)
+            throws SaslException {
+        byte[] bytes = saslServer.evaluateResponse(authBytes);
+
+        if (saslServer.isComplete()) {
+            validateTransition(State.AUTHN_SUCCESS);
+            String authorizationId = saslServer.getAuthorizationID();
+            String[] properties = SaslMechanism.fromMechanismName(saslServer.getMechanismName()).negotiableProperties();
+            Map<String, Object> negotiatedProperty = new HashMap<>((int) (properties.length * 4.0 / 3));
+            for (String property : properties) {
+                Object value = saslServer.getNegotiatedProperty(property);
+                if (value != null) {
+                    negotiatedProperty.put(property, value);
+                }
+            }
+            saslServer.dispose();
+            ctx.fireUserEventTriggered(new AuthenticationEvent(authorizationId,
+                    negotiatedProperty));
+
+        }
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MyDecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MyDecodePredicate.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.internal.codec.DecodePredicate;
+
+class MyDecodePredicate implements DecodePredicate {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MyDecodePredicate.class);
+
+    private final boolean handleSasl;
+    private DecodePredicate delegate = null;
+
+    public MyDecodePredicate(boolean handleSasl) {
+        this.handleSasl = handleSasl;
+    }
+
+    public void setDelegate(DecodePredicate delegate) {
+        LOGGER.debug("Setting delegate {}", delegate);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
+        boolean result;
+        if (apiKey == ApiKeys.API_VERSIONS) {
+            // TODO For now let's assume we need to always decode this, since the NetHandler
+            // currently does this. At some point we'll need a way to figure out the mutual intersection
+            // of api versions over all backend clusters plus the proxy itself.
+            result = true;
+        }
+        else if (apiKey == ApiKeys.SASL_HANDSHAKE
+                || apiKey == ApiKeys.SASL_AUTHENTICATE) {
+            result = handleSasl;
+        }
+        else {
+            result = delegate == null ? true : delegate.shouldDecodeRequest(apiKey, apiVersion);
+        }
+        // return result;
+        return true;
+    }
+
+    @Override
+    public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
+        // return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "MyDecodePredicate(" +
+                "handleSasl=" + handleSasl +
+                ", delegate=" + delegate +
+                ')';
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
@@ -11,14 +11,14 @@ import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.internal.codec.DecodePredicate;
 
-class MyDecodePredicate implements DecodePredicate {
+class SaslDecodePredicate implements DecodePredicate {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MyDecodePredicate.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaslDecodePredicate.class);
 
     private final boolean handleSasl;
     private DecodePredicate delegate = null;
 
-    public MyDecodePredicate(boolean handleSasl) {
+    public SaslDecodePredicate(boolean handleSasl) {
         this.handleSasl = handleSasl;
     }
 
@@ -43,14 +43,12 @@ class MyDecodePredicate implements DecodePredicate {
         else {
             result = delegate == null ? true : delegate.shouldDecodeRequest(apiKey, apiVersion);
         }
-        // return result;
-        return true;
+        return result;
     }
 
     @Override
     public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
-        // return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
-        return true;
+        return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/DecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/DecodePredicate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.codec;
+
+import java.util.Arrays;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+/**
+ * Encapsulates decisions about whether requests and responses should be
+ * fully deserialized into POJOs, or passed through as byte buffers with
+ * minimal deserialization.
+ *
+ * The actual decision can depend on which filters are in use, which can depend on
+ * who the authorized user or, or which back-end cluster they're connected to.
+ */
+public interface DecodePredicate {
+    public static DecodePredicate forFilters(KrpcFilter... filters) {
+        return new DecodePredicate() {
+            @Override
+            public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
+                for (var filter : filters) {
+                    if (filter.shouldDeserializeResponse(apiKey, apiVersion)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
+                for (var filter : filters) {
+                    if (filter.shouldDeserializeRequest(apiKey, apiVersion)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return "DecodePredicate$forFilters{" + Arrays.toString(filters) + "}";
+            }
+        };
+    }
+
+    public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion);
+
+    public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion);
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.authenticator.CredentialCache;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandler;
+import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
+import org.apache.kafka.common.security.scram.internals.ScramMessages;
+import org.apache.kafka.common.security.scram.internals.ScramServerCallbackHandler;
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.frame.BareSaslRequest;
+import io.kroxylicious.proxy.frame.BareSaslResponse;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.codec.CorrelationManager;
+import io.kroxylicious.proxy.internal.future.PromiseImpl;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KafkaAuthnHandlerTest {
+
+    public static final String CLIENT_SOFTWARE_NAME = "my-test-client";
+    public static final String CLIENT_SOFTWARE_VERSION = "1.0.0";
+    EmbeddedChannel channel = new EmbeddedChannel();
+    private final CorrelationManager correlationManager = new CorrelationManager();
+    private int corrId = 0;
+    private UserEventCollector userEventCollector;
+    private KafkaAuthnHandler kafkaAuthnHandler;
+
+    private void buildChanneel(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        channel = new EmbeddedChannel();
+        kafkaAuthnHandler = new KafkaAuthnHandler(
+                KafkaAuthnHandler.State.START, mechanismHandlers);
+        channel.pipeline().addLast(kafkaAuthnHandler);
+        userEventCollector = new UserEventCollector();
+        channel.pipeline().addLast(userEventCollector);
+        // channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+        // @Override
+        // public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        // if (msg instanceof DecodedRequestFrame) {
+        // if (((DecodedRequestFrame<?>) msg).body() instanceof ApiVersionsRequestData) {
+        // ctx.writeAndFlush(new DecodedResponseFrame<>(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION,
+        // 1, null, new ApiVersionsResponseData()));
+        // } else {
+        // fail();
+        // }
+        // }
+        // else {
+        // fail();
+        // }
+        // }
+        // });
+    }
+
+    @AfterEach
+    public void after() {
+        channel.checkException();
+    }
+
+    public static List<Object[]> apiVersions() {
+        var result = new ArrayList<Object[]>();
+        for (short apiVersionsVersion = ApiVersionsRequestData.LOWEST_SUPPORTED_VERSION; apiVersionsVersion <= ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION; apiVersionsVersion++) {
+            for (short handshakeVersion = SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION; handshakeVersion <= SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION; handshakeVersion++) {
+                for (short authenticateVersion = SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION; authenticateVersion <= SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION; authenticateVersion++) {
+                    result.add(new Object[]{ apiVersionsVersion, handshakeVersion, authenticateVersion });
+                }
+            }
+        }
+        return result;
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSuccessfulSaslPlainAuth(
+                                            short apiVersionsVersion,
+                                            short saslHandshakeVersion,
+                                            short saslAuthenticateVersion) {
+
+        buildChanneel(Map.of(KafkaAuthnHandler.SaslMechanism.PLAIN, saslPlainCallbackHandler()));
+
+        // ApiVersions should propagate
+        ApiVersionsRequestData apiVersionsRequest = new ApiVersionsRequestData()
+                .setClientSoftwareName(CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(CLIENT_SOFTWARE_VERSION);
+        writeRequest(apiVersionsVersion, apiVersionsRequest);
+
+        var cse = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect DecodedRequestFrame");
+        assertInstanceOf(ApiVersionsRequestData.class, cse.body(),
+                "Expected ApiVersions request to be propagated to next handler");
+
+        // We don't expect an ApiVersions response, because there is no handler in the pipeline
+        // which will send one
+
+        // Other requests should be denied
+        MetadataRequestData metadataRequest1 = new MetadataRequestData();
+        metadataRequest1.topics().add(new MetadataRequestData.MetadataRequestTopic().setName("topic"));
+
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest1);
+        assertNull(channel.readInbound(),
+                "Non-ApiVersions equests should not propagate prior to successful authn");
+        MetadataResponseData metadataResponse1 = readResponse(MetadataResponseData.class);
+        assertEquals(Errors.ILLEGAL_SASL_STATE.code(), metadataResponse1.topics().iterator().next().errorCode());
+
+        SaslHandshakeRequestData handshakeRequest = new SaslHandshakeRequestData()
+                .setMechanism("PLAIN");
+        writeRequest(saslHandshakeVersion, handshakeRequest);
+        var handshakeResponseBody = readResponse(SaslHandshakeResponseData.class);
+        assertEquals(Errors.NONE.code(), handshakeResponseBody.errorCode());
+
+        if (saslHandshakeVersion == 0) {
+            var bare = new BareSaslRequest("fred\0fred\0foo".getBytes(StandardCharsets.UTF_8), true);
+            channel.writeInbound(bare);
+            BareSaslResponse response = assertInstanceOf(BareSaslResponse.class, channel.readOutbound());
+            assertEquals(0, response.bytes().length);
+        }
+        else {
+            SaslAuthenticateRequestData authenticateRequest = new SaslAuthenticateRequestData()
+                    .setAuthBytes("fred\0fred\0foo".getBytes(StandardCharsets.UTF_8));
+            writeRequest(saslAuthenticateVersion, authenticateRequest);
+            SaslAuthenticateResponseData saslAuthenticateResponseData = readResponse(SaslAuthenticateResponseData.class);
+            assertEquals(Errors.NONE.code(), saslAuthenticateResponseData.errorCode());
+        }
+
+        // SASL server should be complete
+        assertTrue(kafkaAuthnHandler.saslServer.isComplete());
+
+        // Event should be propagated
+        var ae = assertInstanceOf(AuthenticationEvent.class, userEventCollector.readUserEvent(),
+                "Expect authentication event");
+        assertEquals("fred", ae.authorizationId());
+        assertTrue(ae.negotiatedProperties().isEmpty());
+        assertNull(userEventCollector.readUserEvent(), "Expected a single authn event");
+
+        // Subsequent events should be passed upstream
+        MetadataRequestData metadataRequest = new MetadataRequestData();
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest);
+        var followingFrame = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect RPC following successful authentication to be propagated");
+        assertInstanceOf(MetadataRequestData.class, followingFrame.body());
+
+    }
+
+    private PlainServerCallbackHandler saslPlainCallbackHandler() {
+        PlainServerCallbackHandler plainServerCallbackHandler = new PlainServerCallbackHandler();
+        plainServerCallbackHandler.configure(Map.of(),
+                KafkaAuthnHandler.SaslMechanism.PLAIN.mechanismName(),
+                List.of(new AppConfigurationEntry(PlainLoginModule.class.getName(),
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                        Map.of("user_fred", "foo"))));
+        return plainServerCallbackHandler;
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSuccessfulSaslScramSha256Auth(
+                                                  short apiVersionsVersion,
+                                                  short saslHandshakeVersion,
+                                                  short saslAuthenticateVersion)
+            throws Exception {
+        successfulSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_256, apiVersionsVersion, saslHandshakeVersion, saslAuthenticateVersion);
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSuccessfulSaslScramSha512Auth(
+                                                  short apiVersionsVersion,
+                                                  short saslHandshakeVersion,
+                                                  short saslAuthenticateVersion)
+            throws Exception {
+        successfulSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_512, apiVersionsVersion, saslHandshakeVersion, saslAuthenticateVersion);
+    }
+
+    private void successfulSaslScramShaAuth(
+                                            KafkaAuthnHandler.SaslMechanism saslMechanism,
+                                            short apiVersionsVersion,
+                                            short saslHandshakeVersion,
+                                            short saslAuthenticateVersion)
+            throws Exception {
+
+        buildChanneel(Map.of(saslMechanism, saslScramShaCallbackHandler(saslMechanism)));
+
+        // ApiVersions should propagate
+        ApiVersionsRequestData apiVersionsRequest = new ApiVersionsRequestData()
+                .setClientSoftwareName(CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(CLIENT_SOFTWARE_VERSION);
+        writeRequest(apiVersionsVersion, apiVersionsRequest);
+
+        var cse = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect DecodedRequestFrame");
+        assertInstanceOf(ApiVersionsRequestData.class, cse.body(),
+                "Expected ApiVersions request to be propagated to next handler");
+
+        // We don't expect an ApiVersions response, because there is no handler in the pipeline
+        // which will send one
+
+        // Other requests should be denied
+        MetadataRequestData metadataRequest1 = new MetadataRequestData();
+        metadataRequest1.topics().add(new MetadataRequestData.MetadataRequestTopic().setName("topic"));
+
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest1);
+        assertNull(channel.readInbound(),
+                "Non-ApiVersions equests should not propagate prior to successful authn");
+        MetadataResponseData metadataResponse1 = readResponse(MetadataResponseData.class);
+        assertEquals(Errors.ILLEGAL_SASL_STATE.code(), metadataResponse1.topics().iterator().next().errorCode());
+
+        SaslHandshakeRequestData handshakeRequest = new SaslHandshakeRequestData()
+                .setMechanism(saslMechanism.mechanismName());
+        writeRequest(saslHandshakeVersion, handshakeRequest);
+        var handshakeResponseBody = readResponse(SaslHandshakeResponseData.class);
+        assertEquals(Errors.NONE.code(), handshakeResponseBody.errorCode());
+
+        ScramFormatter scramFormatter = new ScramFormatter(saslMechanism.scramMechanism());
+
+        // First authenticate
+        ScramMessages.ClientFirstMessage clientFirst = new ScramMessages.ClientFirstMessage("fred", scramFormatter.secureRandomString(), Map.of());
+        ScramMessages.ServerFirstMessage serverFirstMessage;
+        if (saslHandshakeVersion == 0) {
+            var bare = new BareSaslRequest(clientFirst.toBytes(), true);
+            channel.writeInbound(bare);
+            BareSaslResponse response = assertInstanceOf(BareSaslResponse.class, channel.readOutbound());
+            assertNotEquals(0, response.bytes().length);
+            serverFirstMessage = new ScramMessages.ServerFirstMessage(response.bytes());
+        }
+        else {
+            SaslAuthenticateRequestData authenticateRequest = new SaslAuthenticateRequestData()
+                    .setAuthBytes(clientFirst.toBytes());
+            writeRequest(saslAuthenticateVersion, authenticateRequest);
+            SaslAuthenticateResponseData saslAuthenticateResponseData = readResponse(SaslAuthenticateResponseData.class);
+            assertEquals(Errors.NONE.code(), saslAuthenticateResponseData.errorCode());
+            serverFirstMessage = new ScramMessages.ServerFirstMessage(saslAuthenticateResponseData.authBytes());
+        }
+
+        // Second authenticate
+        byte[] passwordBytes = ScramFormatter.normalize(new String("password"));
+        var saltedPassword = scramFormatter.hi(passwordBytes, serverFirstMessage.salt(), serverFirstMessage.iterations());
+        ScramMessages.ClientFinalMessage clientFinal = new ScramMessages.ClientFinalMessage("n,,".getBytes(StandardCharsets.UTF_8), serverFirstMessage.nonce());
+        byte[] clientProof = scramFormatter.clientProof(saltedPassword, clientFirst, serverFirstMessage, clientFinal);
+        clientFinal.proof(clientProof);
+
+        if (saslHandshakeVersion == 0) {
+            var bare = new BareSaslRequest(clientFinal.toBytes(), true);
+            channel.writeInbound(bare);
+            BareSaslResponse response = assertInstanceOf(BareSaslResponse.class, channel.readOutbound());
+            assertNotEquals(0, response.bytes().length);
+        }
+        else {
+            SaslAuthenticateRequestData authenticateRequest = new SaslAuthenticateRequestData()
+                    .setAuthBytes(clientFinal.toBytes());
+            writeRequest(saslAuthenticateVersion, authenticateRequest);
+            SaslAuthenticateResponseData saslAuthenticateResponseData = readResponse(SaslAuthenticateResponseData.class);
+            assertEquals(Errors.NONE.code(), saslAuthenticateResponseData.errorCode());
+        }
+
+        // TODO assertions on the final server response
+
+        // SASL server should be complete
+        assertTrue(kafkaAuthnHandler.saslServer.isComplete());
+
+        // Event should be propagated
+        var ae = assertInstanceOf(AuthenticationEvent.class, userEventCollector.readUserEvent(),
+                "Expect authentication event");
+        assertEquals("fred", ae.authorizationId());
+        assertTrue(ae.negotiatedProperties().isEmpty());
+        assertNull(userEventCollector.readUserEvent(), "Expected a single authn event");
+
+        // Subsequent events should be passed upstream
+        MetadataRequestData metadataRequest = new MetadataRequestData();
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest);
+        var followingFrame = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect RPC following successful authentication to be propagated");
+        assertInstanceOf(MetadataRequestData.class, followingFrame.body());
+
+    }
+
+    private ScramServerCallbackHandler saslScramShaCallbackHandler(KafkaAuthnHandler.SaslMechanism saslMechanism) {
+        CredentialCache.Cache<ScramCredential> credentialCache = new CredentialCache.Cache<>(ScramCredential.class);
+        ScramCredential credential;
+        try {
+            credential = new ScramFormatter(saslMechanism.scramMechanism()).generateCredential("password", 4096);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        credentialCache.put("fred", credential);
+        ScramServerCallbackHandler callbackHandler = new ScramServerCallbackHandler(credentialCache, new DelegationTokenCache(List.of(saslMechanism.mechanismName())));
+        callbackHandler.configure(null, saslMechanism.mechanismName(), null);
+        return callbackHandler;
+    }
+
+    private <T extends ApiMessage> T readResponse(Class<T> cls) {
+        DecodedResponseFrame<?> authenticateResponseFrame = assertInstanceOf(DecodedResponseFrame.class, channel.readOutbound());
+        return assertInstanceOf(cls, authenticateResponseFrame.body());
+    }
+
+    private void writeRequest(short apiVersion, ApiMessage body) {
+        var apiKey = ApiKeys.forId(body.apiKey());
+
+        int downstreamCorrelationId = corrId++;
+
+        short headerVersion = apiKey.requestHeaderVersion(apiVersion);
+        RequestHeaderData header = new RequestHeaderData()
+                .setRequestApiKey(apiKey.id)
+                .setRequestApiVersion(apiVersion)
+                .setClientId("client-id")
+                .setCorrelationId(downstreamCorrelationId);
+
+        correlationManager.putBrokerRequest(body.apiKey(), apiVersion, downstreamCorrelationId, true, new KrpcFilter() {
+            @Override
+            public void onRequest(DecodedRequestFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+
+            }
+
+            @Override
+            public void onResponse(DecodedResponseFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+
+            }
+
+            @Override
+            public boolean shouldDeserializeResponse(ApiKeys apiKey, short apiVersion) {
+                return true;
+            }
+        }, new PromiseImpl<>(), true);
+
+        channel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
+    }
+
+    // TODO check the unsuccessful authentication case
+    // TODO check the bad password case
+    // TODO check the scram sha mechanisms
+    // TODO check that unexpected state transitions are handled with disconnection
+    // TODO check that unknown read type (like ProxyDecodeEvent) propagate to upstream handlers
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -70,22 +70,6 @@ public class KafkaAuthnHandlerTest {
         channel.pipeline().addLast(kafkaAuthnHandler);
         userEventCollector = new UserEventCollector();
         channel.pipeline().addLast(userEventCollector);
-        // channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-        // @Override
-        // public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        // if (msg instanceof DecodedRequestFrame) {
-        // if (((DecodedRequestFrame<?>) msg).body() instanceof ApiVersionsRequestData) {
-        // ctx.writeAndFlush(new DecodedResponseFrame<>(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION,
-        // 1, null, new ApiVersionsResponseData()));
-        // } else {
-        // fail();
-        // }
-        // }
-        // else {
-        // fail();
-        // }
-        // }
-        // });
     }
 
     @AfterEach

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/UserEventCollector.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/UserEventCollector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * A ChannelInboundHandlerAdapter which allows asserting which users events were fired
+ * both other prior handlers in a netty pipeline.
+ */
+public class UserEventCollector extends ChannelInboundHandlerAdapter {
+    List<Object> events = new ArrayList<>();
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        Objects.requireNonNull(evt);
+        events.add(evt);
+        super.userEventTriggered(ctx, evt);
+    }
+
+    public Object readUserEvent() {
+        return events.isEmpty() ? null : events.remove(0);
+    }
+
+    public List<Object> userEvents() {
+        return events;
+    }
+
+    public void clearUserEvents() {
+        events.clear();
+    }
+}


### PR DESCRIPTION
Implement a Netty handler which understands the `SaslHandshake` and `SaslAuthenticate` RPCs and it able to propagate the authenticated user's identify to other handlers in the pipeline. 

This handler is not integrated with the rest of the code in this PR: That will be done later.

Fixes #74