### PR TITLE
Integration test based on native kafka (Experiment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ $ mvn clean verify
 
 The running of the tests can be controlled with the following Maven properties:
 
-| property          | description            |
-|-------------------|------------------------|
-| `-DskipUTs=true`  | skip unit tests        |
-| `-DskipITs=true`  | skip integration tests |
-| `-DskiTests=true` | skip all tests         |
+| property           | description            |
+|--------------------|------------------------|
+| `-DskipUTs=true`   | skip unit tests        |
+| `-DskipITs=true`   | skip integration tests |
+| `-DskipTests=true` | skip all tests         |
 
 The kafka environment used by the integrations tests can be _defaulted_ with these two environment variables.
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,22 @@ Build the project like this:
 $ mvn clean verify
 ```
 
-Optionally, skip long-running system tests like this:
+The running of the tests can be controlled with the following Maven properties:
 
-```
-$ mvn clean verify -DexcludedGroups="system-test"
-```
+| property          | description            |
+|-------------------|------------------------|
+| `-DskipUTs=true`  | skip unit tests        |
+| `-DskipITs=true`  | skip integration tests |
+| `-DskiTests=true` | skip all tests         |
 
-Pass the `-Dquick` option to skip all non-essential plug-ins and create the output artifact as quickly as possible:
+The kafka environment used by the integrations tests can be _defaulted_ with these two environment variables.
+
+| env var                   | default | description                                                                                                  |
+|---------------------------|---------|--------------------------------------------------------------------------------------------------------------|
+| `TEST_CLUSTER_IN_VM`      | `true`  | if true, kafka will be run same virtual machines as the integration test. Otherwise containers will be used. |
+| `TEST_CLUSTER_KRAFT_MODE` | `true`  | if true, kafka will be run in kraft mode.                                                                    |
+
+Pass the `-Dquick` option to skip all tests and non-essential plug-ins and create the output artifact as quickly as possible:
 
 ```
 $ mvn clean verify -Dquick

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>integrationtests</artifactId>
-    <description>Integration tests where kroxylicious is tested end to end with a kafka cluster.</description>
+    <description>Integration tests where Kroxylicious is tested end-to-end with a real Kafka cluster.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -73,13 +73,13 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -103,6 +103,9 @@
                         <!-- https://github.com/containers/podman/issues/7927#issuecomment-731525556 - required for testcontainers/podman support -->
                         <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
                     </environmentVariables>
+                    <systemProperties>
+                        <container.logs.dir>${build.directory}/container-logs/</container.logs.dir>
+                    </systemProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kroxylicious-parent</artifactId>
+        <groupId>io.kroxylicious</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integrationtests</artifactId>
+    <description>Integration tests where kroxylicious is tested end to end with a kafka cluster.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.13</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <!-- https://github.com/containers/podman/issues/7927#issuecomment-731525556 - required for testcontainers/podman support -->
+                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
+                    </environmentVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/Cluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/Cluster.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testcluster;
+
+import java.util.Map;
+
+public interface Cluster extends AutoCloseable {
+    /**
+     * starts the cluster.  use #close will stop it again.
+     */
+    void start();
+
+    /**
+     * Gets the bootstrap servers for this cluster
+     * @return bootstrap servers
+     */
+    String getBootstrapServers();
+
+    /**
+     * Gets the kafka connect config for this cluster.  Details such the bootstrap and SASL configuration
+     * are provided automatically.  The return map may be muted by the caller.
+     *
+     * @return mutable kafka connect config map
+     */
+    Map<String, Object> getConnectConfigForCluster();
+}

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ClusterConfig.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ClusterConfig.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.testcluster;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.SaslConfigs;
+
+import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints.Endpoint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+
+@Builder(toBuilder = true)
+@Getter
+@ToString
+public class ClusterConfig {
+
+    /**
+     * if true, cluster will use an in-VM kafka
+     */
+    private final Boolean inVM;
+    /**
+     * if true, the cluster will be brought up in Kraft-mode
+     */
+    private final Boolean kraftMode;
+
+    /**
+     * name of SASL mechanism to be configured on kafka for the external listener, if null, anonymous communication
+     * will be used.
+     */
+    private final String saslMechanism;
+    @Builder.Default
+    private Integer brokersNum = 1;
+
+    private final String kafkaKraftClusterId = Uuid.randomUuid().toString();
+    /**
+     * The users and passwords to be configured into the server's JAAS configuration used for the external listener.
+     */
+    @Singular
+    private final Map<String, String> users;
+
+    public Stream<ConfigHolder> getBrokerConfigs(Supplier<KafkaEndpoints> endPointConfigSupplier, Supplier<Endpoint> zookeeperEndpointSupplier) {
+        List<ConfigHolder> properties = new ArrayList<>();
+        KafkaEndpoints kafkaEndpoints = endPointConfigSupplier.get();
+        for (int brokerNum = 0; brokerNum < brokersNum; brokerNum++) {
+            Properties server = new Properties();
+
+            server.put("broker.id", brokerNum);
+
+            var interBrokerEndpoint = kafkaEndpoints.getInterBrokerEndpoint(brokerNum);
+            var clientEndpoint = kafkaEndpoints.getClientEndpoint(brokerNum);
+
+            // - EXTERNAL: used for communications to/from consumers/producers
+            // - INTERNAL: used for inter-broker communications (always no auth)
+            // - CONTROLLER: used for inter-broker controller communications (kraft - always no auth)
+
+            var externalListenerTransport = saslMechanism == null ? "PLAINTEXT" : "SASL_PLAINTEXT";
+
+            var protocolMap = new TreeMap<>();
+            var listeners = new TreeMap<>();
+            var advertisedListeners = new TreeMap<>();
+            protocolMap.put("EXTERNAL", externalListenerTransport);
+            listeners.put("EXTERNAL", clientEndpoint.getBind().toString());
+            advertisedListeners.put("EXTERNAL", clientEndpoint.getConnect().toString());
+
+            protocolMap.put("INTERNAL", "PLAINTEXT");
+            listeners.put("INTERNAL", interBrokerEndpoint.getBind().toString());
+            advertisedListeners.put("INTERNAL", interBrokerEndpoint.getConnect().toString());
+            server.put("inter.broker.listener.name", "INTERNAL");
+
+            if (isKraftMode()) {
+                var controllerEndpoint = kafkaEndpoints.getControllerEndpoint(brokerNum);
+                var quorumVoters = IntStream.range(0, this.brokersNum)
+                        .mapToObj(b -> String.format("%d@%s", b, kafkaEndpoints.getControllerEndpoint(b).getConnect().toString())).collect(Collectors.joining(","));
+
+                server.put("process.roles", "broker,controller");
+
+                server.put("controller.listener.names", "CONTROLLER");
+                server.put("controller.quorum.voters", quorumVoters);
+
+                protocolMap.put("CONTROLLER", "PLAINTEXT");
+                listeners.put("CONTROLLER", controllerEndpoint.getBind().toString());
+            }
+            else {
+                server.put("zookeeper.connect", String.format("%s:%d", zookeeperEndpointSupplier.get().getHost(), zookeeperEndpointSupplier.get().getPort()));
+                server.put("zookeeper.sasl.enabled", "false");
+            }
+
+            server.put("listener.security.protocol.map", protocolMap.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(",")));
+            server.put("listeners", listeners.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(",")));
+            server.put("advertised.listeners", advertisedListeners.entrySet().stream().map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(",")));
+
+            if (saslMechanism != null) {
+                server.put("sasl.enabled.mechanisms", saslMechanism);
+
+                var saslPairs = new StringBuilder();
+
+                Optional.of(users).orElse(Map.of()).forEach((key, value) -> {
+                    saslPairs.append(String.format("user_%s", key));
+                    saslPairs.append("=");
+                    saslPairs.append(value);
+                    saslPairs.append(" ");
+                });
+
+                // TODO support other than PLAIN
+                String plainModuleConfig = String.format("org.apache.kafka.common.security.plain.PlainLoginModule required %s;", saslPairs);
+                server.put(String.format("listener.name.%s.plain.sasl.jaas.config", "EXTERNAL".toLowerCase()), plainModuleConfig);
+            }
+
+            // 1 partition for the __consumer_offsets_ topic should be enough
+            server.put("offsets.topic.num.partitions", Integer.toString(1));
+            // Disable delay during every re-balance
+            server.put("group.initial.rebalance.delay.ms", Integer.toString(0));
+
+            properties.add(new ConfigHolder(server, clientEndpoint.getConnect().getPort(),
+                    String.format("%s:%d", clientEndpoint.getConnect().getHost(), clientEndpoint.getConnect().getPort()), brokerNum, kafkaKraftClusterId));
+        }
+
+        return properties.stream();
+    }
+
+    protected Map<String, Object> getConnectConfigForCluster(String bootstrapServers) {
+        Map<String, Object> kafkaConfig = new HashMap<>();
+        String saslMechanism = getSaslMechanism();
+        if (saslMechanism != null) {
+            kafkaConfig.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
+            kafkaConfig.put(SaslConfigs.SASL_MECHANISM, saslMechanism);
+
+            Map<String, String> users = getUsers();
+            if ("PLAIN".equals(saslMechanism) && !users.isEmpty()) {
+                var first = users.entrySet().iterator().next();
+                kafkaConfig.put(SaslConfigs.SASL_JAAS_CONFIG,
+                        String.format("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";",
+                                first.getKey(), first.getValue()));
+            }
+            else {
+                throw new IllegalStateException(String.format("unsupported SASL mechanism %s", saslMechanism));
+            }
+        }
+
+        kafkaConfig.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        return kafkaConfig;
+    }
+
+    public boolean isKraftMode() {
+        return this.getKraftMode() == null || this.getKraftMode();
+    }
+
+    @Builder
+    @Getter
+    public static class ConfigHolder {
+        private final Properties properties;
+        private final Integer externalPort;
+        private final String endpoint;
+        private final int brokerNum;
+        private final String kafkaKraftClusterId;
+    }
+
+    protected interface KafkaEndpoints {
+
+        @Builder
+        @Getter
+        class EndpointPair {
+            private final Endpoint bind;
+            private final Endpoint connect;
+        }
+
+        @Builder
+        @Getter
+        class Endpoint {
+            private final String host;
+            private final int port;
+
+            @Override
+            public String toString() {
+                return String.format("//%s:%d", host, port);
+            }
+        }
+
+        EndpointPair getInterBrokerEndpoint(int brokerNum);
+
+        EndpointPair getControllerEndpoint(int brokerNum);
+
+        EndpointPair getClientEndpoint(int brokerNum);
+    }
+}

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ClusterConfig.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ClusterConfig.java
@@ -62,7 +62,7 @@ public class ClusterConfig {
         for (int brokerNum = 0; brokerNum < brokersNum; brokerNum++) {
             Properties server = new Properties();
 
-            server.put("broker.id", brokerNum);
+            server.put("broker.id", Integer.toString(brokerNum));
 
             var interBrokerEndpoint = kafkaEndpoints.getInterBrokerEndpoint(brokerNum);
             var clientEndpoint = kafkaEndpoints.getClientEndpoint(brokerNum);
@@ -124,6 +124,7 @@ public class ClusterConfig {
                 server.put(String.format("listener.name.%s.plain.sasl.jaas.config", "EXTERNAL".toLowerCase()), plainModuleConfig);
             }
 
+            server.put("offsets.topic.replication.factor", Integer.toString(1));
             // 1 partition for the __consumer_offsets_ topic should be enough
             server.put("offsets.topic.num.partitions", Integer.toString(1));
             // Disable delay during every re-balance

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ClusterFactory.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ClusterFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.testcluster;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClusterFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterFactory.class);
+
+    /**
+     * provides default inVM setting for callers that do not provide a inVM.
+     */
+    public static final String TEST_CLUSTER_IN_VM_DEFAULT = "TEST_CLUSTER_IN_VM";
+
+    /**
+     * provides default kraftMode setting for callers that do not provide a KraftMode.
+     */
+    public static final String TEST_CLUSTER_KRAFT_MODE_DEFAULT = "TEST_CLUSTER_KRAFT_MODE";
+
+    public static Cluster create(ClusterConfig clusterConfig) {
+        if (clusterConfig == null) {
+            throw new NullPointerException();
+        }
+
+        var builder = clusterConfig.toBuilder();
+
+        var defaults = System.getenv().entrySet().stream()
+                .filter(e -> e.getKey().startsWith("TEST_CLUSTER_")).map(ClusterFactory::convert)
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (x, y) -> y, LinkedHashMap::new));
+
+        defaults.putIfAbsent(TEST_CLUSTER_IN_VM_DEFAULT, true);
+        defaults.putIfAbsent(TEST_CLUSTER_KRAFT_MODE_DEFAULT, true);
+
+        defaults.forEach((key, value) -> {
+            switch (key) {
+                case TEST_CLUSTER_IN_VM_DEFAULT:
+                    if (clusterConfig.getInVM() == null) {
+                        builder.inVM(value);
+                    }
+                    break;
+                case TEST_CLUSTER_KRAFT_MODE_DEFAULT:
+                    if (clusterConfig.getKraftMode() == null) {
+                        builder.kraftMode(value);
+                    }
+                    break;
+                default:
+                    LOGGER.warn("Unrecognised environment variable : {}", key);
+            }
+        });
+
+        var actual = builder.build();
+        LOGGER.info("Test cluster : {}", actual);
+
+        if (actual.getInVM()) {
+            return new InVMKafkaCluster(actual);
+        }
+        else {
+            return new ContainerBasedKafkaCluster(actual);
+        }
+    }
+
+    private static Entry<String, Boolean> convert(Entry<String, String> e) {
+        return new SimpleEntry<>(e.getKey(), Boolean.parseBoolean(e.getValue()));
+    }
+}

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ContainerBasedKafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ContainerBasedKafkaCluster.java
@@ -40,7 +40,7 @@ import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints.Endpoint;
 import lombok.SneakyThrows;
 
 /**
- * Provides an easy way to launch a Kafka cluster with multiple brokers.
+ * Provides an easy way to launch a Kafka cluster with multiple brokers in a container
  */
 public class ContainerBasedKafkaCluster implements Startable, Cluster {
 

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ContainerBasedKafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ContainerBasedKafkaCluster.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.testcluster;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startable;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints;
+import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints.Endpoint;
+import lombok.SneakyThrows;
+
+/**
+ * Provides an easy way to launch a Kafka cluster with multiple brokers.
+ */
+public class ContainerBasedKafkaCluster implements Startable, Cluster {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerBasedKafkaCluster.class);
+    public static final int KAFKA_PORT = 9093;
+    public static final int ZOOKEEPER_PORT = 2181;
+    private static final DockerImageName DEFAULT_KAFKA_IMAGE = DockerImageName.parse("bitnami/kafka:latest");
+    private static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE = DockerImageName.parse("bitnami/zookeeper:latest");
+    private static final int READY_TIMEOUT_SECONDS = 120;
+    private final DockerImageName kafkaImage;
+    private final DockerImageName zookeeperImage;
+    private final ClusterConfig clusterConfig;
+    private final Network network = Network.newNetwork();
+    private final GenericContainer<?> zookeeper;
+    private final Collection<KafkaContainer> brokers;
+
+    static {
+        if (!System.getenv().containsValue("TESTCONTAINERS_RYUK_DISABLED")) {
+            LOGGER.warn("As per https://github.com/containers/podman/issues/7927#issuecomment-731525556 if using podman, set env var TESTCONTAINERS_RYUK_DISABLED=true");
+        }
+    }
+
+    public ContainerBasedKafkaCluster(ClusterConfig clusterConfig) {
+        this(null, null, clusterConfig);
+    }
+
+    public ContainerBasedKafkaCluster(DockerImageName kafkaImage, DockerImageName zookeeperImage, ClusterConfig clusterConfig) {
+        this.kafkaImage = Optional.ofNullable(kafkaImage).orElse(DEFAULT_KAFKA_IMAGE);
+        this.zookeeperImage = Optional.ofNullable(zookeeperImage).orElse(DEFAULT_ZOOKEEPER_IMAGE);
+        this.clusterConfig = clusterConfig;
+
+        if (this.clusterConfig.isKraftMode()) {
+            this.zookeeper = null;
+        }
+        else {
+            MountableFile logFile = MountableFile.forClasspathResource("zookeeper_logback.xml");
+            this.zookeeper = new GenericContainer<>(this.zookeeperImage)
+                    .withNetwork(network)
+                    .withNetworkAliases("zookeeper")
+                    .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
+                    .withEnv("ZOO_PORT_NUMBER", String.valueOf(ZOOKEEPER_PORT))
+                    .withCopyFileToContainer(logFile, "/tmp/");
+        }
+
+        Supplier<KafkaEndpoints> endPointConfigSupplier = () -> new KafkaEndpoints() {
+            final List<Integer> ports = Utils.preAllocateListeningPorts(clusterConfig.getBrokersNum()).collect(Collectors.toList());
+
+            @Override
+            public EndpointPair getClientEndpoint(int brokerNum) {
+                return EndpointPair.builder().bind(new Endpoint("0.0.0.0", 9093)).connect(new Endpoint("localhost", ports.get(brokerNum))).build();
+            }
+
+            @Override
+            public EndpointPair getInterBrokerEndpoint(int brokerNum) {
+                return EndpointPair.builder().bind(new Endpoint("0.0.0.0", 9092)).connect(new Endpoint(String.format("broker-%d", brokerNum), 9092)).build();
+            }
+
+            @Override
+            public EndpointPair getControllerEndpoint(int brokerNum) {
+                return EndpointPair.builder().bind(new Endpoint("0.0.0.0", 9091)).connect(new Endpoint(String.format("broker-%d", brokerNum), 9091)).build();
+            }
+        };
+        Supplier<Endpoint> zookeeperEndpointSupplier = () -> new Endpoint("zookeeper", ContainerBasedKafkaCluster.ZOOKEEPER_PORT);
+        this.brokers = clusterConfig.getBrokerConfigs(endPointConfigSupplier, zookeeperEndpointSupplier).map(holder -> {
+            String netAlias = "broker-" + holder.getBrokerNum();
+            MountableFile kafkaJaasConf = MountableFile.forClasspathResource("kafka_jaas.conf");
+            KafkaContainer kafkaContainer = new KafkaContainer(this.kafkaImage)
+                    .withNetwork(this.network)
+                    .withNetworkAliases(netAlias)
+                    .withEnv("KAFKA_BROKER_ID", holder.getBrokerNum() + "")
+                    .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")
+                    .withEnv("BITNAMI_DEBUG", "true")
+                    .withEnv("XSHELLOPTS", "xtrace")
+                    .withStartupTimeout(Duration.ofMinutes(2))
+                    .withCopyFileToContainer(kafkaJaasConf, "/opt/bitnami/kafka/config/");
+
+            kafkaContainer.addFixedExposedPort(holder.getExternalPort(), KAFKA_PORT);
+
+            // Once https://github.com/docker-java/docker-java/pull/1963 is available, we will be able to copy
+            // these properties to the container as server.properties, and avoid the need to map the properties
+            // into environment variables.
+            // kafkaContainer.withCopyFileToContainer(..properties.., "/opt/bitnami/kafka/config/");
+
+            kafkaContainer.withEnv(serverPropertiesToBitnamiEnvVar(holder.getProperties()));
+
+            if (this.clusterConfig.isKraftMode()) {
+                return kafkaContainer
+                        .withEnv("KAFKA_ENABLE_KRAFT", "yes")
+                        .withEnv("KAFKA_KRAFT_CLUSTER_ID", holder.getKafkaKraftClusterId());
+            }
+            else {
+                return kafkaContainer.dependsOn(this.zookeeper);
+            }
+        }).collect(Collectors.toList());
+    }
+
+    private Map<String, String> serverPropertiesToBitnamiEnvVar(Properties serverProperties) {
+        Map<String, String> envVars = new HashMap<>();
+        serverProperties.entrySet().forEach(p -> envVars.put("KAFKA_CFG_" + p.getKey().toString().toUpperCase().replace('.', '_'), p.getValue().toString()));
+        return envVars;
+    }
+
+    @Override
+    public String getBootstrapServers() {
+        return brokers.stream()
+                .map(b -> String.format("localhost:%d", b.getMappedPort(KAFKA_PORT)))
+                .collect(Collectors.joining(","));
+    }
+
+    private Stream<GenericContainer<?>> allContainers() {
+        return Stream.concat(
+                this.brokers.stream(),
+                Stream.ofNullable(this.zookeeper));
+    }
+
+    @Override
+    @SneakyThrows
+    public void start() {
+        try {
+            if (zookeeper != null) {
+                zookeeper.start();
+                Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
+                    Container.ExecResult result = this.zookeeper.execInContainer(
+                            "sh", "-c",
+                            String.format("_JAVA_OPTIONS=-Dlogback.configurationFile=/tmp/zookeeper_logback.xml zkCli.sh -server zookeeper:%s whoami", ZOOKEEPER_PORT));
+                    LOGGER.debug("zookeeper running {} / {} / exit {}", result.getStdout(), result.getStderr(), result.getExitCode());
+                    return result.getExitCode() == 0;
+                });
+            }
+            Startables.deepStart(brokers.stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException | ExecutionException | TimeoutException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            stop();
+            throw new RuntimeException("startup failed or timed out", e);
+        }
+
+        if (clusterConfig.isKraftMode()) {
+            Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
+                Container.ExecResult result = this.brokers.iterator().next().execInContainer(
+                        "sh", "-c",
+                        "kafka-metadata-shell.sh --snapshot /bitnami/kafka/data/__cluster_metadata-0/*.log ls /brokers");
+                LOGGER.debug("kraft cluster ready probe {} / {} / exit {}", result.getStdout(), result.getStderr(), result.getExitCode());
+                Optional<String> brokers = Optional.ofNullable(result.getStdout());
+                return brokers.map(b -> Arrays.stream(b.split(System.lineSeparator())).count()).map(count -> count.intValue() == this.clusterConfig.getBrokersNum())
+                        .orElse(false);
+            });
+        }
+        else {
+            Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
+                Container.ExecResult result = this.zookeeper.execInContainer(
+                        "sh", "-c",
+                        String.format("_JAVA_OPTIONS=-Dlogback.configurationFile=/tmp/zookeeper_logback.xml zkCli.sh -server zookeeper:%s ls /brokers/ids | tail -n 1",
+                                ZOOKEEPER_PORT));
+                LOGGER.debug("zookeeper cluster ready probe {} / {} / exit {}", result.getStdout(), result.getStderr(), result.getExitCode());
+                String brokers = result.getStdout();
+
+                return brokers != null && brokers.split(",").length == this.clusterConfig.getBrokersNum();
+            });
+        }
+    }
+
+    @Override
+    public void stop() {
+        allContainers().parallel().forEach(GenericContainer::stop);
+    }
+
+    @Override
+    public Map<String, Object> getConnectConfigForCluster() {
+        return clusterConfig.getConnectConfigForCluster(getBootstrapServers());
+    }
+
+    // In kraft mode, currently "Advertised listeners cannot be altered when using a Raft-based metadata quorum", so we
+    // need to know the listening port before we start the kafka container. For this reason, we need this override
+    // to expose addFixedExposedPort to for use.
+    public static class KafkaContainer extends GenericContainer<KafkaContainer> {
+        public KafkaContainer(final DockerImageName dockerImageName) {
+            super(dockerImageName);
+        }
+
+        protected void addFixedExposedPort(int hostPort, int containerPort) {
+            super.addFixedExposedPort(hostPort, containerPort);
+        }
+    }
+}

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ContainerBasedKafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/ContainerBasedKafkaCluster.java
@@ -5,13 +5,31 @@
  */
 package io.kroxylicious.proxy.testcluster;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints;
+import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints.Endpoint;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.TestInfo;
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.lifecycle.Startable;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Arrays;
+import java.time.OffsetDateTime;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,22 +41,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.rnorth.ducttape.unreliables.Unreliables;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.Container;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.images.builder.Transferable;
-import org.testcontainers.lifecycle.Startable;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.MountableFile;
-
-import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints;
-import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints.Endpoint;
-import lombok.SneakyThrows;
-
 /**
  * Provides an easy way to launch a Kafka cluster with multiple brokers in a container
  */
@@ -47,14 +49,16 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
     private static final Logger LOGGER = LoggerFactory.getLogger(ContainerBasedKafkaCluster.class);
     public static final int KAFKA_PORT = 9093;
     public static final int ZOOKEEPER_PORT = 2181;
-    private static final DockerImageName DEFAULT_KAFKA_IMAGE = DockerImageName.parse("bitnami/kafka:latest");
-    private static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE = DockerImageName.parse("bitnami/zookeeper:latest");
+    private static final DockerImageName DEFAULT_KAFKA_IMAGE = DockerImageName.parse("quay.io/k_wall/kafka-native:1.0.0-SNAPSHOT");
+    private static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE = DockerImageName.parse("quay.io/k_wall/zookeeper-native:1.0.0-SNAPSHOT");
     private static final int READY_TIMEOUT_SECONDS = 120;
+    private static final String KAFKA_CLUSTER_READY_FLAG = "/tmp/kafka_cluster_ready";
+    private static final String ZOOKEEPER_READY_FLAG = "/tmp/kafka_zookeeper_ready";
     private final DockerImageName kafkaImage;
     private final DockerImageName zookeeperImage;
     private final ClusterConfig clusterConfig;
     private final Network network = Network.newNetwork();
-    private final GenericContainer<?> zookeeper;
+    private final ZookeeperContainer zookeeper;
     private final Collection<KafkaContainer> brokers;
 
     static {
@@ -72,17 +76,22 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
         this.zookeeperImage = Optional.ofNullable(zookeeperImage).orElse(DEFAULT_ZOOKEEPER_IMAGE);
         this.clusterConfig = clusterConfig;
 
+        var name = Optional.ofNullable(clusterConfig.getTestInfo())
+                .map(TestInfo::getDisplayName)
+                .map(s -> s.replaceFirst("\\(\\)$", ""))
+                .map(s -> String.format("%s.%s", s, OffsetDateTime.now()))
+                .orElse(null);
+
         if (this.clusterConfig.isKraftMode()) {
             this.zookeeper = null;
         }
         else {
-            var logFile = MountableFile.forClasspathResource("zookeeper_logback.xml", 0644);
-            this.zookeeper = new GenericContainer<>(this.zookeeperImage)
+            this.zookeeper = new ZookeeperContainer(this.zookeeperImage)
+                    .withName(name)
                     .withNetwork(network)
-                    .withNetworkAliases("zookeeper")
-                    .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
-                    .withEnv("ZOO_PORT_NUMBER", String.valueOf(ZOOKEEPER_PORT))
-                    .withCopyToContainer(logFile, "/tmp/zookeeper_logback.xml");
+                    .withEnv("SERVER_ZOOKEEPER_READY_FLAG_FILE", ZOOKEEPER_READY_FLAG)
+//                    .withEnv("QUARKUS_LOG_LEVEL", "DEBUG")  // Enable org.apache.zookeeper logging too
+                    .withNetworkAliases("zookeeper");
         }
 
         Supplier<KafkaEndpoints> endPointConfigSupplier = () -> new KafkaEndpoints() {
@@ -106,30 +115,25 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
         Supplier<Endpoint> zookeeperEndpointSupplier = () -> new Endpoint("zookeeper", ContainerBasedKafkaCluster.ZOOKEEPER_PORT);
         this.brokers = clusterConfig.getBrokerConfigs(endPointConfigSupplier, zookeeperEndpointSupplier).map(holder -> {
             String netAlias = "broker-" + holder.getBrokerNum();
-            var kafkaJaasConf = MountableFile.forClasspathResource("kafka_jaas.conf", 0644);
             KafkaContainer kafkaContainer = new KafkaContainer(this.kafkaImage)
+                    .withName(name)
                     .withNetwork(this.network)
                     .withNetworkAliases(netAlias)
-                    .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")
-                    .withEnv("BITNAMI_DEBUG", "true")
-                    .withEnv("XSHELLOPTS", "xtrace")
-                    .withCopyToContainer(Transferable.of(propertiesToBytes(holder.getProperties()), 0666), "/opt/bitnami/kafka/config/server.properties")
-                    .withCopyToContainer(kafkaJaasConf, "/opt/bitnami/kafka/config/kafka_jaas.conf")
+//                  .withEnv("QUARKUS_LOG_LEVEL", "DEBUG")  // Enable org.apache.kafka logging too
+                    .withEnv("SERVER_PROPERTIES_FILE", "/cnf/server.properties" )
+                    .withEnv("SERVER_CLUSTER_ID", holder.getKafkaKraftClusterId() )
+                    .withEnv("SERVER_CLUSTER_READY_FLAG_FILE", KAFKA_CLUSTER_READY_FLAG)
+                    .withEnv("SERVER_CLUSTER_READY_NUM_BROKERS", clusterConfig.getBrokersNum().toString() )
+                    .withCopyToContainer(Transferable.of(propertiesToBytes(holder.getProperties()), 0644), "/cnf/server.properties")
                     .withStartupTimeout(Duration.ofMinutes(2));
+
 
             kafkaContainer.addFixedExposedPort(holder.getExternalPort(), KAFKA_PORT);
 
-            // The Bitnami scripts requires that some properties are set as env vars.
-            kafkaContainer.withEnv(serverPropertiesToBitnamiEnvVar(holder.getProperties()));
-
-            if (this.clusterConfig.isKraftMode()) {
-                return kafkaContainer
-                        .withEnv("KAFKA_ENABLE_KRAFT", "yes")
-                        .withEnv("KAFKA_KRAFT_CLUSTER_ID", holder.getKafkaKraftClusterId());
+            if (!this.clusterConfig.isKraftMode()) {
+                kafkaContainer.dependsOn(this.zookeeper);
             }
-            else {
-                return kafkaContainer.dependsOn(this.zookeeper);
-            }
+            return kafkaContainer;
         }).collect(Collectors.toList());
     }
 
@@ -140,12 +144,6 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    private Map<String, String> serverPropertiesToBitnamiEnvVar(Properties serverProperties) {
-        Map<String, String> envVars = new HashMap<>();
-        serverProperties.entrySet().forEach(p -> envVars.put("KAFKA_CFG_" + p.getKey().toString().toUpperCase().replace('.', '_'), p.getValue().toString()));
-        return envVars;
     }
 
     @Override
@@ -167,13 +165,7 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
         try {
             if (zookeeper != null) {
                 zookeeper.start();
-                Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
-                    Container.ExecResult result = this.zookeeper.execInContainer(
-                            "sh", "-c",
-                            String.format("_JAVA_OPTIONS=-Dlogback.configurationFile=/tmp/zookeeper_logback.xml zkCli.sh -server zookeeper:%s whoami", ZOOKEEPER_PORT));
-                    LOGGER.debug("zookeeper running {} / {} / exit {}", result.getStdout(), result.getStderr(), result.getExitCode());
-                    return result.getExitCode() == 0;
-                });
+                awaitContainerReadyFlagFile(zookeeper, ZOOKEEPER_READY_FLAG);
             }
             Startables.deepStart(brokers.stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
@@ -185,29 +177,17 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
             throw new RuntimeException("startup failed or timed out", e);
         }
 
-        if (clusterConfig.isKraftMode()) {
-            Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
-                Container.ExecResult result = this.brokers.iterator().next().execInContainer(
-                        "sh", "-c",
-                        "kafka-metadata-shell.sh --snapshot /bitnami/kafka/data/__cluster_metadata-0/*.log ls /brokers");
-                LOGGER.debug("kraft cluster ready probe {} / {} / exit {}", result.getStdout(), result.getStderr(), result.getExitCode());
-                Optional<String> brokers = Optional.ofNullable(result.getStdout());
-                return brokers.map(b -> Arrays.stream(b.split(System.lineSeparator())).count()).map(count -> count.intValue() == this.clusterConfig.getBrokersNum())
-                        .orElse(false);
-            });
-        }
-        else {
-            Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
-                Container.ExecResult result = this.zookeeper.execInContainer(
-                        "sh", "-c",
-                        String.format("_JAVA_OPTIONS=-Dlogback.configurationFile=/tmp/zookeeper_logback.xml zkCli.sh -server zookeeper:%s ls /brokers/ids | tail -n 1",
-                                ZOOKEEPER_PORT));
-                LOGGER.debug("zookeeper cluster ready probe {} / {} / exit {}", result.getStdout(), result.getStderr(), result.getExitCode());
-                String brokers = result.getStdout();
+        awaitContainerReadyFlagFile(this.brokers.iterator().next(), KAFKA_CLUSTER_READY_FLAG);
+    }
 
-                return brokers != null && brokers.split(",").length == this.clusterConfig.getBrokersNum();
-            });
-        }
+    private void awaitContainerReadyFlagFile(GenericContainer<?> container, String kafkaClusterReadyFlag) {
+        Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
+            container.execInContainer(
+                    "sh", "-c",
+                    String.format("while [ ! -f %s ]; do sleep .1; done", kafkaClusterReadyFlag));
+            LOGGER.info("Container {} ready", container.getDockerImageName());
+            return true;
+        });
     }
 
     @Override
@@ -223,7 +203,8 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
     // In kraft mode, currently "Advertised listeners cannot be altered when using a Raft-based metadata quorum", so we
     // need to know the listening port before we start the kafka container. For this reason, we need this override
     // to expose addFixedExposedPort to for use.
-    public static class KafkaContainer extends GenericContainer<KafkaContainer> {
+    public static class KafkaContainer extends LoggingGenericContainer<KafkaContainer> {
+
         public KafkaContainer(final DockerImageName dockerImageName) {
             super(dockerImageName);
         }
@@ -231,5 +212,59 @@ public class ContainerBasedKafkaCluster implements Startable, Cluster {
         protected void addFixedExposedPort(int hostPort, int containerPort) {
             super.addFixedExposedPort(hostPort, containerPort);
         }
+
     }
+    public static class ZookeeperContainer extends LoggingGenericContainer<ZookeeperContainer> {
+        public ZookeeperContainer(DockerImageName zookeeperImage) {
+            super(zookeeperImage);
+        }
+    }
+
+    public static class LoggingGenericContainer<C extends GenericContainer<C>>
+            extends GenericContainer<C> {
+        private static final String CONTAINER_LOGS_DIR = "container.logs.dir";
+        private String name;
+
+        public LoggingGenericContainer(DockerImageName dockerImageName) {
+            super(dockerImageName);
+        }
+
+        @Override
+        protected void containerIsStarting(InspectContainerResponse containerInfo) {
+            super.containerIsStarting(containerInfo);
+
+            Optional.ofNullable(System.getProperty(CONTAINER_LOGS_DIR)).ifPresent(logDir -> {
+                var target = Path.of(logDir);
+                if (name != null) {
+                    target = target.resolve(name);
+                }
+                target = target.resolve(String.format("%s.%s.%s", getContainerName().replaceFirst(File.separator, ""), getContainerId(), "log"));
+                target.getParent().toFile().mkdirs();
+                try {
+                    var writer = new FileWriter(target.toFile());
+                    super.followOutput(outputFrame -> {
+                        try {
+                            if (outputFrame.equals(OutputFrame.END)) {
+                                writer.close();
+                            } else {
+                                writer.write(outputFrame.getUtf8String());
+                            }
+                        } catch (IOException e) {
+                            // ignore
+                        }
+                    });
+                } catch (IOException e) {
+                    logger().warn("Failed to create container log file: {}", target);
+                }
+            });
+
+        }
+
+        public LoggingGenericContainer<C> withName(String name) {
+            this.name = name;
+            return this;
+        }
+    }
+
+
 }

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/InVMKafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/InVMKafkaCluster.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testcluster;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.testcluster.ClusterConfig.ConfigHolder;
+import io.kroxylicious.proxy.testcluster.ClusterConfig.KafkaEndpoints;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaRaftServer;
+import kafka.server.KafkaServer;
+import kafka.server.Server;
+import kafka.tools.StorageTool;
+import scala.Option;
+
+public class InVMKafkaCluster implements Cluster {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InVMKafkaCluster.class);
+
+    private final ClusterConfig clusterConfig;
+    private final Path tempDirectory;
+    private final ServerCnxnFactory zooFactory;
+    private final ZooKeeperServer zooServer;
+    private List<Server> servers;
+    private List<String> bootstraps = new ArrayList<>();
+
+    public InVMKafkaCluster(ClusterConfig clusterConfig) {
+        this.clusterConfig = clusterConfig;
+        try {
+            tempDirectory = Files.createTempDirectory("kafka");
+
+            var numPorts = clusterConfig.getBrokersNum() * (clusterConfig.isKraftMode() ? 3 : 2) + (clusterConfig.isKraftMode() ? 0 : 1);
+            LinkedList<Integer> ports = Utils.preAllocateListeningPorts(numPorts).collect(Collectors.toCollection(LinkedList::new));
+
+            final Supplier<KafkaEndpoints.Endpoint> zookeeperEndpointSupplier;
+            if (!clusterConfig.isKraftMode()) {
+                var zookeeperPort = ports.pop();
+
+                zooFactory = ServerCnxnFactory.createFactory(new InetSocketAddress("localhost", zookeeperPort), 1024);
+
+                var zoo = tempDirectory.resolve("zoo");
+                var snapshotDir = zoo.resolve("snapshot");
+                var logDir = zoo.resolve("log");
+                snapshotDir.toFile().mkdirs();
+                logDir.toFile().mkdirs();
+
+                zooServer = new ZooKeeperServer(snapshotDir.toFile(), logDir.toFile(), 500);
+                zookeeperEndpointSupplier = () -> new KafkaEndpoints.Endpoint("localhost", zookeeperPort);
+            }
+            else {
+                zooFactory = null;
+                zooServer = null;
+                zookeeperEndpointSupplier = null;
+            }
+
+            Supplier<KafkaEndpoints> kafkaEndpointsSupplier = () -> new KafkaEndpoints() {
+                final List<Integer> clientPorts = ports.subList(0, clusterConfig.getBrokersNum());
+                final List<Integer> interBrokerPorts = ports.subList(clusterConfig.getBrokersNum(), 2 * clusterConfig.getBrokersNum());
+                final List<Integer> controllerPorts = ports.subList(clusterConfig.getBrokersNum() * 2, ports.size());
+
+                @Override
+                public EndpointPair getClientEndpoint(int brokerNum) {
+                    var port = clientPorts.get(brokerNum);
+                    return EndpointPair.builder().bind(new Endpoint("0.0.0.0", port)).connect(new Endpoint("localhost", port)).build();
+                }
+
+                @Override
+                public EndpointPair getInterBrokerEndpoint(int brokerNum) {
+                    var port = interBrokerPorts.get(brokerNum);
+                    return EndpointPair.builder().bind(new Endpoint("0.0.0.0", port)).connect(new Endpoint("localhost", port)).build();
+                }
+
+                @Override
+                public EndpointPair getControllerEndpoint(int brokerNum) {
+                    if (!clusterConfig.isKraftMode()) {
+                        throw new IllegalStateException();
+                    }
+                    var port = controllerPorts.get(brokerNum);
+                    return EndpointPair.builder().bind(new Endpoint("0.0.0.0", port)).connect(new Endpoint("localhost", port)).build();
+                }
+            };
+
+            servers = clusterConfig.getBrokerConfigs(kafkaEndpointsSupplier, zookeeperEndpointSupplier).map(this::buildKafkaServer).collect(Collectors.toList());
+
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @NotNull
+    private Server buildKafkaServer(ConfigHolder c) {
+        bootstraps.add(c.getEndpoint());
+        KafkaConfig config = buildBrokerConfig(c, tempDirectory);
+        Option<String> threadNamePrefix = Option.apply(null);
+
+        boolean kraftMode = clusterConfig.isKraftMode();
+        if (kraftMode) {
+            var directories = StorageTool.configToLogDirectories(config);
+            var clusterId = c.getKafkaKraftClusterId();
+            var metaProperties = StorageTool.buildMetadataProperties(clusterId, config);
+            StorageTool.formatCommand(System.out, directories, metaProperties, true);
+            return new KafkaRaftServer(config, Time.SYSTEM, threadNamePrefix);
+        }
+        else {
+            return new KafkaServer(config, Time.SYSTEM, threadNamePrefix, false);
+
+        }
+    }
+
+    @NotNull
+    private KafkaConfig buildBrokerConfig(ConfigHolder c, Path tempDirectory) {
+        Properties properties = new Properties();
+        properties.putAll(c.getProperties());
+        Path logsDir = tempDirectory.resolve(String.format("broker-%d", c.getBrokerNum()));
+        properties.setProperty(KafkaConfig.LogDirProp(), logsDir.toAbsolutePath().toString());
+        properties.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp(), String.valueOf(1));
+
+        return new KafkaConfig(properties);
+    }
+
+    @Override
+    public void start() {
+        if (zooFactory != null) {
+            try {
+                zooFactory.startup(zooServer);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                zooServer.shutdown(true);
+                return;
+            }
+        }
+
+        servers.stream().parallel().forEach(Server::startup);
+
+    }
+
+    @Override
+    public String getBootstrapServers() {
+        return String.join(",", bootstraps);
+    }
+
+    @Override
+    public Map<String, Object> getConnectConfigForCluster() {
+        return clusterConfig.getConnectConfigForCluster(getBootstrapServers());
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            servers.stream().parallel().forEach(Server::shutdown);
+            bootstraps.clear();
+
+            if (zooServer != null) {
+                zooServer.shutdown(true);
+            }
+        }
+        finally {
+            if (tempDirectory.toFile().exists()) {
+                try (var s = Files.walk(tempDirectory)
+                        .sorted(Comparator.reverseOrder())
+                        .map(Path::toFile)) {
+                    s.forEach(File::delete);
+                }
+            }
+        }
+    }
+}

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/InVMKafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/InVMKafkaCluster.java
@@ -137,7 +137,6 @@ public class InVMKafkaCluster implements Cluster {
         properties.putAll(c.getProperties());
         Path logsDir = tempDirectory.resolve(String.format("broker-%d", c.getBrokerNum()));
         properties.setProperty(KafkaConfig.LogDirProp(), logsDir.toAbsolutePath().toString());
-        properties.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp(), String.valueOf(1));
 
         return new KafkaConfig(properties);
     }

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/Utils.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testcluster/Utils.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testcluster;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class Utils {
+    public static Stream<Integer> preAllocateListeningPorts(int num) {
+        if (num < 1) {
+            return Stream.of();
+        }
+        try (var serverSocket = new ServerSocket(0)) {
+            serverSocket.setReuseAddress(true);
+            int localPort = serverSocket.getLocalPort();
+            return Stream.concat(List.of(localPort).stream(), preAllocateListeningPorts(num - 1));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ClusterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ClusterIT.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.testcluster.Cluster;
+import io.kroxylicious.proxy.testcluster.ClusterConfig;
+import io.kroxylicious.proxy.testcluster.ClusterFactory;
+import io.kroxylicious.proxy.testcluster.ContainerBasedKafkaCluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Test case that simply exercises the ability to control the kafka cluster from the test.
+ *
+ */
+public class ClusterIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterIT.class);
+
+    @Test
+    public void kafkaClusterKraftMode() throws Exception {
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().kraftMode(true).build())) {
+            cluster.start();
+            verify(1, cluster);
+        }
+    }
+
+    @Test
+    public void kafkaClusterZookeeperMode() throws Exception {
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().kraftMode(false).build())) {
+            cluster.start();
+            verify(1, cluster);
+        }
+    }
+
+    @Test
+    public void kafkaMultiNodeClusterKraftMode() throws Exception {
+        int brokersNum = 2;
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().brokersNum(brokersNum).kraftMode(true).build())) {
+            assumeTrue(cluster instanceof ContainerBasedKafkaCluster, "FIXME: kraft timing out on shutdown in multinode case");
+            cluster.start();
+            verify(brokersNum, cluster);
+        }
+    }
+
+    @Test
+    public void kafkaMultiNodeClusterZookeeperMode() throws Exception {
+        int brokersNum = 2;
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().brokersNum(brokersNum).kraftMode(false).build())) {
+            cluster.start();
+            verify(brokersNum, cluster);
+        }
+    }
+
+    @Test
+    public void kafkaClusterKraftModeWithAuth() throws Exception {
+        try (var cluster = ClusterFactory.create(
+                ClusterConfig.builder().kraftMode(true).saslMechanism("PLAIN").user("guest", "guest").build())) {
+            cluster.start();
+            verify(1, cluster);
+        }
+    }
+
+    @Test
+    public void kafkaClusterZookeeperModeWithAuth() throws Exception {
+        try (var cluster = ClusterFactory.create(
+                ClusterConfig.builder().kraftMode(false).saslMechanism("PLAIN").user("guest", "guest").build())) {
+            cluster.start();
+            verify(1, cluster);
+        }
+    }
+
+    private void verify(int expected, Cluster cluster) throws Exception {
+        var topic = "TOPIC_1";
+        var message = "Hello, world!";
+
+        try (var admin = KafkaAdminClient.create(cluster.getConnectConfigForCluster())) {
+            assertEquals(expected, getActualNumberOfBrokers(admin));
+            var rf = (short) Math.min(1, Math.max(expected, 3));
+            createTopic(admin, topic, rf);
+        }
+
+        produce(cluster, topic, message);
+        consume(cluster, topic, "Hello, world!");
+    }
+
+    private void produce(Cluster cluster, String topic, String message) throws Exception {
+        Map<String, Object> config = cluster.getConnectConfigForCluster();
+        config.putAll(Map.<String, Object> of(
+                ProducerConfig.CLIENT_ID_CONFIG, "myclient",
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+        try (var producer = new KafkaProducer<String, String>(config)) {
+            producer.send(new ProducerRecord<>(topic, "my-key", message)).get();
+        }
+    }
+
+    private void consume(Cluster cluster, String topic, String message) throws Exception {
+        Map<String, Object> config = cluster.getConnectConfigForCluster();
+        config.putAll(Map.of(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                ConsumerConfig.GROUP_ID_CONFIG, "my-group-id",
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+        try (var consumer = new KafkaConsumer<String, String>(config)) {
+            consumer.subscribe(Set.of(topic));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertEquals(1, records.count());
+            assertEquals(message, records.iterator().next().value());
+        }
+    }
+
+    private int getActualNumberOfBrokers(AdminClient admin) throws Exception {
+        DescribeClusterResult describeClusterResult = admin.describeCluster();
+        return describeClusterResult.nodes().get().size();
+    }
+
+    private void createTopic(AdminClient admin1, String topic, short replicationFactor) throws Exception {
+        admin1.createTopics(List.of(new NewTopic(topic, 1, replicationFactor))).all().get();
+    }
+
+    @BeforeEach
+    void before(TestInfo testInfo) {
+        LOGGER.warn("Running {}", testInfo.getTestMethod().get().getName());
+    }
+
+    @AfterEach
+    void after(TestInfo testInfo) {
+        LOGGER.warn("Done running {}", testInfo.getTestMethod().get().getName());
+    }
+
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ClusterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ClusterIT.java
@@ -43,10 +43,11 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class ClusterIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterIT.class);
+    private TestInfo testInfo;
 
     @Test
     public void kafkaClusterKraftMode() throws Exception {
-        try (var cluster = ClusterFactory.create(ClusterConfig.builder().kraftMode(true).build())) {
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().testInfo(testInfo).kraftMode(true).build())) {
             cluster.start();
             verify(1, cluster);
         }
@@ -54,16 +55,16 @@ public class ClusterIT {
 
     @Test
     public void kafkaClusterZookeeperMode() throws Exception {
-        try (var cluster = ClusterFactory.create(ClusterConfig.builder().kraftMode(false).build())) {
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().testInfo(testInfo).kraftMode(false).build())) {
             cluster.start();
             verify(1, cluster);
         }
     }
 
     @Test
-    public void kafkaMultiNodeClusterKraftMode() throws Exception {
+    public void kafkaTwoNodeClusterKraftMode() throws Exception {
         int brokersNum = 2;
-        try (var cluster = ClusterFactory.create(ClusterConfig.builder().brokersNum(brokersNum).kraftMode(true).build())) {
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().testInfo(testInfo).brokersNum(brokersNum).kraftMode(true).build())) {
             assumeTrue(cluster instanceof ContainerBasedKafkaCluster, "FIXME: kraft timing out on shutdown in multinode case");
             cluster.start();
             verify(brokersNum, cluster);
@@ -71,9 +72,9 @@ public class ClusterIT {
     }
 
     @Test
-    public void kafkaMultiNodeClusterZookeeperMode() throws Exception {
+    public void kafkaTwoNodeClusterZookeeperMode() throws Exception {
         int brokersNum = 2;
-        try (var cluster = ClusterFactory.create(ClusterConfig.builder().brokersNum(brokersNum).kraftMode(false).build())) {
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().testInfo(testInfo).brokersNum(brokersNum).kraftMode(false).build())) {
             cluster.start();
             verify(brokersNum, cluster);
         }
@@ -82,7 +83,7 @@ public class ClusterIT {
     @Test
     public void kafkaClusterKraftModeWithAuth() throws Exception {
         try (var cluster = ClusterFactory.create(
-                ClusterConfig.builder().kraftMode(true).saslMechanism("PLAIN").user("guest", "guest").build())) {
+                ClusterConfig.builder().kraftMode(true).testInfo(testInfo).saslMechanism("PLAIN").user("guest", "guest").build())) {
             cluster.start();
             verify(1, cluster);
         }
@@ -91,7 +92,7 @@ public class ClusterIT {
     @Test
     public void kafkaClusterZookeeperModeWithAuth() throws Exception {
         try (var cluster = ClusterFactory.create(
-                ClusterConfig.builder().kraftMode(false).saslMechanism("PLAIN").user("guest", "guest").build())) {
+                ClusterConfig.builder().testInfo(testInfo).kraftMode(false).saslMechanism("PLAIN").user("guest", "guest").build())) {
             cluster.start();
             verify(1, cluster);
         }
@@ -149,6 +150,7 @@ public class ClusterIT {
 
     @BeforeEach
     void before(TestInfo testInfo) {
+        this.testInfo = testInfo;
         LOGGER.warn("Running {}", testInfo.getTestMethod().get().getName());
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.ConfigParser;
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.internal.filter.ByteBufferTransformation;
+import io.kroxylicious.proxy.testcluster.ClusterConfig;
+import io.kroxylicious.proxy.testcluster.ClusterFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KrpcFilterIT {
+
+    private static final String TOPIC_1 = "my-test-topic";
+    private static final String TOPIC_2 = "other-test-topic";
+    private static final String PLAINTEXT = "Hello, world!";
+    private static final byte[] TOPIC_1_CIPHERTEXT = { (byte) 0x3d, (byte) 0x5a, (byte) 0x61, (byte) 0x61, (byte) 0x64, (byte) 0x21, (byte) 0x15, (byte) 0x6c,
+            (byte) 0x64, (byte) 0x67, (byte) 0x61, (byte) 0x59, (byte) 0x16 };
+    private static final byte[] TOPIC_2_CIPHERTEXT = { (byte) 0xffffffa7, (byte) 0xffffffc4, (byte) 0xffffffcb, (byte) 0xffffffcb, (byte) 0xffffffce, (byte) 0xffffff8b,
+            (byte) 0x7f, (byte) 0xffffffd6, (byte) 0xffffffce, (byte) 0xffffffd1, (byte) 0xffffffcb, (byte) 0xffffffc3, (byte) 0xffffff80 };
+
+    @BeforeAll
+    public static void checkReversibleEncryption() {
+        // The precise details of the cipher don't matter
+        // What matters is that it the ciphertext key depends on the topic name
+        // and that decode() is the inverse of encode()
+        assertArrayEquals(TOPIC_1_CIPHERTEXT, encode(TOPIC_1, ByteBuffer.wrap(PLAINTEXT.getBytes(StandardCharsets.UTF_8))).array());
+        assertEquals(PLAINTEXT, new String(decode(TOPIC_1, ByteBuffer.wrap(TOPIC_1_CIPHERTEXT)).array(), StandardCharsets.UTF_8));
+        assertArrayEquals(TOPIC_2_CIPHERTEXT, encode(TOPIC_2, ByteBuffer.wrap(PLAINTEXT.getBytes(StandardCharsets.UTF_8))).array());
+        assertEquals(PLAINTEXT, new String(decode(TOPIC_2, ByteBuffer.wrap(TOPIC_2_CIPHERTEXT)).array(), StandardCharsets.UTF_8));
+    }
+
+    public static class TestEncoder implements ByteBufferTransformation {
+
+        @Override
+        public ByteBuffer transform(String topicName, ByteBuffer in) {
+            return encode(topicName, in);
+        }
+    }
+
+    private static ByteBuffer encode(String topicName, ByteBuffer in) {
+        var out = ByteBuffer.allocate(in.limit());
+        byte rot = (byte) (topicName.hashCode() % Byte.MAX_VALUE);
+        // System.out.println("Encode Rot " + rot);
+        for (int index = 0; index < in.limit(); index++) {
+            byte b = in.get(index);
+            byte rotated = (byte) (b + rot);
+            // System.out.println("rotate(" + b + ", " + rot + "): " + rotated);
+            out.put(index, rotated);
+        }
+        return out;
+    }
+
+    public static class TestDecoder implements ByteBufferTransformation {
+
+        @Override
+        public ByteBuffer transform(String topicName, ByteBuffer in) {
+            return decode(topicName, in);
+        }
+    }
+
+    private static ByteBuffer decode(String topicName, ByteBuffer in) {
+        var out = ByteBuffer.allocate(in.limit());
+        out.limit(in.limit());
+        byte rot = (byte) -(topicName.hashCode() % Byte.MAX_VALUE);
+        // System.out.println("Decode Rot " + rot);
+        for (int index = 0; index < in.limit(); index++) {
+            byte b = in.get(index);
+            byte rotated = (byte) (b + rot);
+            // System.out.println("rotate(" + b + ", " + rot + "): " + rotated);
+            out.put(index, rotated);
+        }
+        return out;
+    }
+
+    @Test
+    public void shouldPassThroughRecordUnchanged() throws Exception {
+        String proxyAddress = "localhost:9192";
+
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().build())) {
+            cluster.start();
+
+            String bootstrapServers = cluster.getBootstrapServers();
+            try (var admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers))) {
+                admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
+            }
+
+            String config = """
+                    proxy:
+                      address: %s
+                    clusters:
+                      demo:
+                        bootstrap_servers: %s
+                    filters:
+                    - type: ApiVersions
+                    - type: BrokerAddress
+                    """.formatted(proxyAddress, cluster.getBootstrapServers());
+
+            var proxy = startProxy(config);
+
+            var producer = new KafkaProducer<String, String>(Map.of(
+                    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, proxyAddress,
+                    ProducerConfig.CLIENT_ID_CONFIG, "shouldPassThroughRecordUnchanged",
+                    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                    ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", "Hello, world!")).get();
+            producer.close();
+
+            var consumer = new KafkaConsumer<String, String>(Map.of(
+                    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, proxyAddress,
+                    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                    ConsumerConfig.GROUP_ID_CONFIG, "my-group-id",
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+            consumer.subscribe(Set.of(TOPIC_1));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            consumer.close();
+            assertEquals(1, records.count());
+            assertEquals("Hello, world!", records.iterator().next().value());
+
+            // shutdown the proxy
+            proxy.shutdown();
+
+        }
+
+    }
+
+    @Test
+    public void shouldModifyProduceMessage() throws Exception {
+        String proxyAddress = "localhost:9192";
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().build())) {
+            cluster.start();
+            try (var admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers()))) {
+                admin.createTopics(List.of(
+                        new NewTopic(TOPIC_1, 1, (short) 1),
+                        new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
+            }
+
+            String config = """
+                    proxy:
+                      address: %s
+                    clusters:
+                      demo:
+                        bootstrap_servers: %s
+                    filters:
+                    - type: ApiVersions
+                    - type: BrokerAddress
+                    - type: ProduceRequestTransformation
+                      config:
+                        transformation: %s
+                    """.formatted(proxyAddress, cluster.getBootstrapServers(), TestEncoder.class.getName());
+
+            var proxy = startProxy(config);
+            try {
+                try (var producer = new KafkaProducer<String, String>(Map.of(
+                        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, proxyAddress,
+                        ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000))) {
+                    producer.send(new ProducerRecord<>(TOPIC_1, "my-key", PLAINTEXT)).get();
+                    producer.send(new ProducerRecord<>(TOPIC_2, "my-key", PLAINTEXT)).get();
+                    producer.flush();
+                }
+
+                ConsumerRecords<String, byte[]> records1;
+                ConsumerRecords<String, byte[]> records2;
+                try (var consumer = new KafkaConsumer<String, byte[]>(Map.of(
+                        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, proxyAddress,
+                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class,
+                        ConsumerConfig.GROUP_ID_CONFIG, "my-group-id",
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+                    consumer.subscribe(Set.of(TOPIC_1));
+                    records1 = consumer.poll(Duration.ofSeconds(10));
+                    consumer.subscribe(Set.of(TOPIC_2));
+                    records2 = consumer.poll(Duration.ofSeconds(10));
+                }
+
+                assertEquals(1, records1.count());
+                assertArrayEquals(TOPIC_1_CIPHERTEXT, records1.iterator().next().value());
+                assertEquals(1, records2.count());
+                assertArrayEquals(TOPIC_2_CIPHERTEXT, records2.iterator().next().value());
+
+            }
+            finally {
+                // shutdown the proxy
+                proxy.shutdown();
+            }
+
+        }
+    }
+
+    private void printBuf(ByteBuffer buffer) {
+        for (int index = 0; index < 256; index++) {
+            byte i = buffer.get(index);
+            if (i < 16) {
+                System.out.print("0");
+            }
+            System.out.print(Integer.toUnsignedString(i, 16));
+            System.out.print(" ");
+        }
+        System.out.println();
+    }
+
+    @Test
+    public void shouldModifyFetchMessage() throws Exception {
+        String proxyAddress = "localhost:9192";
+        try (var cluster = ClusterFactory.create(ClusterConfig.builder().build())) {
+            cluster.start();
+            try (var admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers()))) {
+                admin.createTopics(List.of(
+                        new NewTopic(TOPIC_1, 1, (short) 1),
+                        new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
+            }
+
+            String config = """
+                    proxy:
+                      address: %s
+                    clusters:
+                      demo:
+                        bootstrap_servers: %s
+                    filters:
+                    - type: ApiVersions
+                    - type: BrokerAddress
+                    - type: FetchResponseTransformation
+                      config:
+                        transformation: %s
+                    """.formatted(proxyAddress, cluster.getBootstrapServers(), TestDecoder.class.getName());
+
+            var proxy = startProxy(config);
+
+            try {
+
+                try (var producer = new KafkaProducer<String, byte[]>(Map.of(
+                        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, proxyAddress,
+                        ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyFetchMessage",
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class,
+                        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000))) {
+
+                    producer.send(new ProducerRecord<>(TOPIC_1, "my-key", TOPIC_1_CIPHERTEXT)).get();
+                    producer.send(new ProducerRecord<>(TOPIC_2, "my-key", TOPIC_2_CIPHERTEXT)).get();
+                }
+
+                ConsumerRecords<String, String> records1;
+                ConsumerRecords<String, String> records2;
+                try (var consumer = new KafkaConsumer<String, String>(Map.of(
+                        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, proxyAddress,
+                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                        ConsumerConfig.GROUP_ID_CONFIG, "my-group-id",
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+                    consumer.subscribe(Set.of(TOPIC_1));
+
+                    records1 = consumer.poll(Duration.ofSeconds(100));
+
+                    consumer.subscribe(Set.of(TOPIC_2));
+
+                    records2 = consumer.poll(Duration.ofSeconds(100));
+                }
+                assertEquals(1, records1.count());
+                assertEquals(1, records2.count());
+                assertEquals(List.of(PLAINTEXT, PLAINTEXT),
+                        List.of(records1.iterator().next().value(),
+                                records2.iterator().next().value()));
+
+            }
+            finally {
+                // shutdown the proxy
+                proxy.shutdown();
+            }
+
+        }
+
+    }
+
+    private KafkaProxy startProxy(String config) throws InterruptedException {
+        Configuration proxyConfig = new ConfigParser().parseConfiguration(config);
+
+        KafkaProxy kafkaProxy = new KafkaProxy(proxyConfig);
+        kafkaProxy.startup();
+
+        return kafkaProxy;
+    }
+
+}

--- a/integrationtests/src/test/resources/kafka_jaas.conf
+++ b/integrationtests/src/test/resources/kafka_jaas.conf
@@ -1,0 +1,7 @@
+//
+// Copyright Kroxylicious Authors.
+//
+// Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+//
+
+// Intentionally empty

--- a/integrationtests/src/test/resources/log4j2-test.properties
+++ b/integrationtests/src/test/resources/log4j2-test.properties
@@ -1,0 +1,72 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name = Config
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
+
+rootLogger.level = WARN
+rootLogger.appenderRefs = console
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false
+
+#logger.kproxy.name = io.kroxylicious.proxy
+#logger.kproxy.level = INFO
+#logger.kproxy.additivity = false
+#logger.kproxy.appenderRef.console.ref = STDOUT
+#
+#logger.internal.name = io.kroxylicious.proxy.internal
+#logger.internal.level = DEBUG
+#logger.internal.additivity = false
+#logger.internal.appenderRef.console.ref = STDOUT
+#
+#logger.netty.name = io.netty
+#logger.netty.level = TRACE
+#logger.netty.additivity = false
+#logger.netty.appenderRef.console.ref = STDOUT
+#
+#logger.broker.name = kafka
+#logger.broker.level = DEBUG
+#logger.broker.additivity = false
+#logger.broker.appenderRef.console.ref = STDOUT
+#
+#logger.scl.name = state.change.logger
+#logger.scl.level = WARN
+#logger.scl.additivity = false
+#logger.scl.appenderRef.console.ref = STDOUT
+#
+#logger.kclients.name = org.apache.kafka
+#logger.kclients.level = DEBUG
+#logger.kclients.additivity = false
+#logger.kclients.appenderRef.console.ref = STDOUT
+#
+
+# The following emit WARN logging during the tests
+# because we're using debezium to spin up clusters
+# so turn down the verbosity to help spot WARN in
+# Kafka or the proxy
+logger.zk.name = org.apache.zookeeper
+logger.zk.level = ERROR
+logger.zk.additivity = false
+logger.zk.appenderRef.console.ref = STDOUT
+
+logger.BrokerMetadataCheckpoint.name = kafka.server.BrokerMetadataCheckpoint
+logger.BrokerMetadataCheckpoint.level = ERROR
+logger.BrokerMetadataCheckpoint.additivity = false
+logger.BrokerMetadataCheckpoint.appenderRef.console.ref = STDOUT
+
+logger.AppInfoParser.name = org.apache.kafka.common.utils.AppInfoParser
+logger.AppInfoParser.level = ERROR
+logger.AppInfoParser.additivity = false
+logger.AppInfoParser.appenderRef.console.ref = STDOUT
+
+logger.TestCluster.name = io.kroxylicious.proxy.testcluster
+logger.TestCluster.level = INFO
+logger.TestCluster.additivity = false
+logger.TestCluster.appenderRef.console.ref = STDOUT

--- a/integrationtests/src/test/resources/zookeeper_logback.xml
+++ b/integrationtests/src/test/resources/zookeeper_logback.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<configuration/>

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -129,38 +129,43 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>
-            <version>${kafka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <!-- required for testcontainers/podman support -->
+                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/KrpcFilterIntegrationTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/KrpcFilterIntegrationTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.kafka.KafkaCluster;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SystemTest
+@Disabled
 public class KrpcFilterIntegrationTest {
 
     private static final String TOPIC_1 = "my-test-topic";

--- a/pom.xml
+++ b/pom.xml
@@ -25,17 +25,27 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+        <skipTests>false</skipTests>
+        <skipITs>${skipTests}</skipITs>
+        <skipUTs>${skipTests}</skipUTs>
+
         <debezium.version>1.9.0.Final</debezium.version>
         <freemarker.version>2.3.31</freemarker.version>
         <jackson.version>2.13.3</jackson.version>
-        <junit.version>5.8.1</junit.version>
+        <junit.version>5.8.2</junit.version>
         <kafka.version>3.2.0</kafka.version>
         <log4j.version>2.17.2</log4j.version>
         <netty.version>4.1.77.Final</netty.version>
+        <testcontainers.version>1.17.3</testcontainers.version>
         <netty.io_uring.version>0.0.14.Final</netty.io_uring.version>
         <netty.epoll.classifier>linux-x86_64</netty.epoll.classifier>
         <netty.io_uring.classifier>linux-x86_64</netty.io_uring.classifier>
         <netty.kqueue.classifier>osx-x86_64</netty.kqueue.classifier>
+        <lombok.version>1.18.24</lombok.version>
+        <assertj-core.version>3.22.0</assertj-core.version>
+        <mockito-core.version>4.6.1</mockito-core.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
+        <zookeeper.version>3.6.3</zookeeper.version>
     </properties>
 
     <name>Kroxylicious Parent</name>
@@ -50,6 +60,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
 
     <dependencyManagement>
         <dependencies>
@@ -89,6 +100,27 @@
                 <version>${kafka.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.13</artifactId>
+                <version>${kafka.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
                 <version>${log4j.version}</version>
@@ -110,7 +142,56 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.36</version>
+                <version>${slf4j-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>kafka</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj-core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito-core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <version>${debezium.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <version>${debezium.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -118,6 +199,7 @@
     <modules>
         <module>krpc-code-gen</module>
         <module>kroxylicious</module>
+        <module>integrationtests</module>
     </modules>
 
     <build>
@@ -194,6 +276,14 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.0.0-M7</version>
+                    <configuration>
+                        <skipTests>${skipITs}</skipTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>3.0.0-M1</version>
                 </plugin>
@@ -205,7 +295,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -221,6 +311,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M5</version>
+                    <configuration>
+                        <skipTests>${skipUTs}</skipTests>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.commonjava.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <java.test.version>17</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>


### PR DESCRIPTION
Based on work from #80 but uses native kafka from https://github.com/ozangunalp/kafka-native (with https://github.com/ozangunalp/kafka-native/pull/1) rather than Bitnami images.

Kafka in kraft mode and zookeeper mode both working for single and multi-node clusters, with/without SASL.
Zookeeper is still in JVM at minute.




