### PR TITLE
Initial implementation of #74: SASL Authentication offload

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.frame;
+
+/**
+ * Ancient versions of Kafka implemented SASL/GSSAPI by sending the token
+ * on the wire as length prefixed bytes (no Kafka protocol header).
+ * This frame represents those kinds of request.
+ *
+ * @see "org.apache.kafka.common.security.authenticator.SaslServerAuthenticator#handleKafkaRequest()"
+ */
+public class BareSaslRequest implements RequestFrame {
+
+    private final byte[] bytes;
+    private final boolean decodeResponse;
+
+    public BareSaslRequest(byte[] bytes, boolean decodeResponse) {
+        this.bytes = bytes;
+        this.decodeResponse = decodeResponse;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return bytes.length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        out.writeByteArray(bytes);
+    }
+
+    @Override
+    public int correlationId() {
+        return 0;
+    }
+
+    @Override
+    public boolean decodeResponse() {
+        return decodeResponse;
+    }
+
+    public byte[] bytes() {
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.frame;
+
+/**
+ * Ancient versions of Kafka implemented SASL/GSSAPI by sending the response
+ * on the wire as length prefixed bytes (no Kafka protocol header).
+ * This frame represents those kinds of response.
+ */
+public class BareSaslResponse implements ResponseFrame {
+
+    private final byte[] bytes;
+
+    public BareSaslResponse(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return bytes.length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        out.writeByteArray(bytes);
+    }
+
+    @Override
+    public int correlationId() {
+        return 0;
+    }
+
+    public byte[] bytes() {
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Sent as a Netty "User Event" by the {@link KafkaAuthnHandler}
+ * to handlers interested in the authenticated user.
+ */
+public class AuthenticationEvent {
+    private final String authorizationId;
+    private final Map<String, Object> negotiatedProperties;
+
+    public AuthenticationEvent(String authorizationId, Map<String, Object> negotiatedProperties) {
+        this.authorizationId = authorizationId;
+        this.negotiatedProperties = Collections.unmodifiableMap(negotiatedProperties);
+    }
+
+    /**
+     * The id that the user authorized with
+     */
+    public String authorizationId() {
+        return authorizationId;
+    }
+
+    /**
+     * Extra authorization state produced by
+     * the authentication process.
+     */
+    public Map<String, Object> negotiatedProperties() {
+        return negotiatedProperties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        AuthenticationEvent that = (AuthenticationEvent) o;
+        return Objects.equals(authorizationId(), that.authorizationId()) && Objects.equals(negotiatedProperties(), that.negotiatedProperties());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authorizationId(), negotiatedProperties());
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/AuthenticationEvent.java
@@ -5,7 +5,6 @@
  */
 package io.kroxylicious.proxy.internal;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -19,7 +18,7 @@ public class AuthenticationEvent {
 
     public AuthenticationEvent(String authorizationId, Map<String, Object> negotiatedProperties) {
         this.authorizationId = authorizationId;
-        this.negotiatedProperties = Collections.unmodifiableMap(negotiatedProperties);
+        this.negotiatedProperties = Map.copyOf(negotiatedProperties);
     }
 
     /**

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -13,20 +13,159 @@ import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 
+import org.apache.kafka.common.ElectionType;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AccessControlEntryFilter;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.errors.IllegalSaslStateException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
+import org.apache.kafka.common.message.AddOffsetsToTxnRequestData;
+import org.apache.kafka.common.message.AddPartitionsToTxnRequestData;
+import org.apache.kafka.common.message.AllocateProducerIdsRequestData;
+import org.apache.kafka.common.message.AlterClientQuotasRequestData;
+import org.apache.kafka.common.message.AlterConfigsRequestData;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.AlterPartitionRequestData;
+import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData;
+import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
+import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
+import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.ControlledShutdownRequestData;
+import org.apache.kafka.common.message.CreateAclsRequestData;
+import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData;
+import org.apache.kafka.common.message.CreateTopicsRequestData;
+import org.apache.kafka.common.message.DeleteAclsRequestData;
+import org.apache.kafka.common.message.DeleteGroupsRequestData;
+import org.apache.kafka.common.message.DeleteRecordsRequestData;
+import org.apache.kafka.common.message.DeleteTopicsRequestData;
+import org.apache.kafka.common.message.DescribeAclsRequestData;
+import org.apache.kafka.common.message.DescribeClientQuotasRequestData;
+import org.apache.kafka.common.message.DescribeClusterRequestData;
+import org.apache.kafka.common.message.DescribeConfigsRequestData;
+import org.apache.kafka.common.message.DescribeDelegationTokenRequestData;
+import org.apache.kafka.common.message.DescribeGroupsRequestData;
+import org.apache.kafka.common.message.DescribeLogDirsRequestData;
+import org.apache.kafka.common.message.DescribeProducersRequestData;
+import org.apache.kafka.common.message.DescribeTransactionsRequestData;
+import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData;
+import org.apache.kafka.common.message.ElectLeadersRequestData;
+import org.apache.kafka.common.message.EndQuorumEpochRequestData;
+import org.apache.kafka.common.message.EndTxnRequestData;
+import org.apache.kafka.common.message.EnvelopeRequestData;
+import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.FetchSnapshotRequestData;
+import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.message.HeartbeatRequestData;
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
+import org.apache.kafka.common.message.InitProducerIdRequestData;
+import org.apache.kafka.common.message.JoinGroupRequestData;
+import org.apache.kafka.common.message.LeaderAndIsrRequestData;
+import org.apache.kafka.common.message.LeaveGroupRequestData;
+import org.apache.kafka.common.message.ListGroupsRequestData;
+import org.apache.kafka.common.message.ListOffsetsRequestData;
+import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.ListTransactionsRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.message.OffsetDeleteRequestData;
+import org.apache.kafka.common.message.OffsetFetchRequestData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.message.SaslAuthenticateRequestData;
 import org.apache.kafka.common.message.SaslAuthenticateResponseData;
 import org.apache.kafka.common.message.SaslHandshakeRequestData;
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.message.StopReplicaRequestData;
+import org.apache.kafka.common.message.SyncGroupRequestData;
+import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
+import org.apache.kafka.common.message.UnregisterBrokerRequestData;
+import org.apache.kafka.common.message.UpdateFeaturesRequestData;
+import org.apache.kafka.common.message.VoteRequestData;
+import org.apache.kafka.common.message.WriteTxnMarkersRequestData;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
+import org.apache.kafka.common.requests.AddPartitionsToTxnRequest;
+import org.apache.kafka.common.requests.AllocateProducerIdsRequest;
+import org.apache.kafka.common.requests.AlterClientQuotasRequest;
+import org.apache.kafka.common.requests.AlterConfigsRequest;
+import org.apache.kafka.common.requests.AlterPartitionReassignmentsRequest;
+import org.apache.kafka.common.requests.AlterPartitionRequest;
+import org.apache.kafka.common.requests.AlterReplicaLogDirsRequest;
+import org.apache.kafka.common.requests.AlterUserScramCredentialsRequest;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
+import org.apache.kafka.common.requests.BeginQuorumEpochRequest;
+import org.apache.kafka.common.requests.BrokerHeartbeatRequest;
+import org.apache.kafka.common.requests.BrokerRegistrationRequest;
+import org.apache.kafka.common.requests.ControlledShutdownRequest;
+import org.apache.kafka.common.requests.CreateAclsRequest;
+import org.apache.kafka.common.requests.CreateDelegationTokenRequest;
+import org.apache.kafka.common.requests.CreatePartitionsRequest;
+import org.apache.kafka.common.requests.CreateTopicsRequest;
+import org.apache.kafka.common.requests.DeleteAclsRequest;
+import org.apache.kafka.common.requests.DeleteGroupsRequest;
+import org.apache.kafka.common.requests.DeleteRecordsRequest;
+import org.apache.kafka.common.requests.DeleteTopicsRequest;
+import org.apache.kafka.common.requests.DescribeAclsRequest;
+import org.apache.kafka.common.requests.DescribeClientQuotasRequest;
+import org.apache.kafka.common.requests.DescribeClusterRequest;
+import org.apache.kafka.common.requests.DescribeConfigsRequest;
+import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
+import org.apache.kafka.common.requests.DescribeGroupsRequest;
+import org.apache.kafka.common.requests.DescribeLogDirsRequest;
+import org.apache.kafka.common.requests.DescribeProducersRequest;
+import org.apache.kafka.common.requests.DescribeTransactionsRequest;
+import org.apache.kafka.common.requests.DescribeUserScramCredentialsRequest;
+import org.apache.kafka.common.requests.ElectLeadersRequest;
+import org.apache.kafka.common.requests.EndQuorumEpochRequest;
+import org.apache.kafka.common.requests.EndTxnRequest;
+import org.apache.kafka.common.requests.EnvelopeRequest;
+import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.FetchSnapshotRequest;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.HeartbeatRequest;
+import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
+import org.apache.kafka.common.requests.InitProducerIdRequest;
+import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.requests.LeaderAndIsrRequest;
+import org.apache.kafka.common.requests.LeaveGroupRequest;
+import org.apache.kafka.common.requests.ListGroupsRequest;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
+import org.apache.kafka.common.requests.ListPartitionReassignmentsRequest;
+import org.apache.kafka.common.requests.ListTransactionsRequest;
 import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.OffsetDeleteRequest;
+import org.apache.kafka.common.requests.OffsetFetchRequest;
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.apache.kafka.common.requests.RenewDelegationTokenRequest;
+import org.apache.kafka.common.requests.StopReplicaRequest;
+import org.apache.kafka.common.requests.SyncGroupRequest;
+import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
+import org.apache.kafka.common.requests.UnregisterBrokerRequest;
+import org.apache.kafka.common.requests.UpdateFeaturesRequest;
+import org.apache.kafka.common.requests.VoteRequest;
+import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePatternFilter;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.authenticator.SaslInternalConfigs;
 import org.apache.kafka.common.security.plain.internals.PlainSaslServerProvider;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
@@ -170,8 +309,6 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
         public abstract Map<String, Object> negotiatedProperties(SaslServer saslServer);
     }
 
-    // TODO need some way to support SaslAuthenticate v0, which doesn't use Kafka protcol framing at all
-
     private final List<String> enabledMechanisms;
 
     @VisibleForTesting
@@ -305,16 +442,321 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
     }
 
     private ApiMessage errorResponse(DecodedRequestFrame<?> frame, Throwable error) {
-        ApiMessage body;
+        /*
+         * This monstrosity is needed because there isn't any _nicely_ abstracted code we can borrow from Kafka
+         * which creates and response with error codes set appropriately.
+         */
+        final AbstractRequest req;
+        ApiMessage reqBody = frame.body();
+        short apiVersion = frame.apiVersion();
         switch (frame.apiKey()) {
-            case METADATA:
-                body = new MetadataRequest((MetadataRequestData) frame.body(), frame.apiVersion()).getErrorResponse(0, error).data();
+            case SASL_HANDSHAKE:
+            case SASL_AUTHENTICATE:
+                // These should have been handled by our caller
+                throw new IllegalStateException();
+            case PRODUCE:
+                req = new ProduceRequest((ProduceRequestData) reqBody, apiVersion);
                 break;
-            // TODO all the other cases!
+            case FETCH:
+                req = new FetchRequest((FetchRequestData) reqBody, apiVersion);
+                break;
+            case LIST_OFFSETS:
+                ListOffsetsRequestData listOffsetsRequestData = (ListOffsetsRequestData) reqBody;
+                if (listOffsetsRequestData.replicaId() == ListOffsetsRequest.CONSUMER_REPLICA_ID) {
+                    req = ListOffsetsRequest.Builder.forConsumer(true, IsolationLevel.forId(listOffsetsRequestData.isolationLevel()), true)
+                            .build(apiVersion);
+                }
+                else {
+                    req = ListOffsetsRequest.Builder.forReplica(apiVersion, listOffsetsRequestData.replicaId())
+                            .build(apiVersion);
+                }
+                break;
+            case METADATA:
+                req = new MetadataRequest((MetadataRequestData) reqBody, apiVersion);
+                break;
+            case OFFSET_COMMIT:
+                req = new OffsetCommitRequest((OffsetCommitRequestData) reqBody, apiVersion);
+                break;
+            case OFFSET_FETCH:
+                OffsetFetchRequestData offsetFetchRequestData = (OffsetFetchRequestData) reqBody;
+                if (offsetFetchRequestData.groups() != null) {
+                    req = new OffsetFetchRequest.Builder(
+                            offsetFetchRequestData.groups().stream().collect(Collectors.toMap(
+                                    OffsetFetchRequestData.OffsetFetchRequestGroup::groupId,
+                                    x -> x.topics().stream().flatMap(
+                                            t -> t.partitionIndexes().stream().map(
+                                                    p -> new TopicPartition(t.name(), p)))
+                                            .collect(Collectors.toList()))),
+                            true, false)
+                                    .build(apiVersion);
+                }
+                else if (offsetFetchRequestData.topics() != null) {
+                    req = new OffsetFetchRequest.Builder(
+                            offsetFetchRequestData.groupId(),
+                            offsetFetchRequestData.requireStable(),
+                            offsetFetchRequestData.topics().stream().flatMap(
+                                    x -> x.partitionIndexes().stream().map(
+                                            p -> new TopicPartition(x.name(), p)))
+                                    .collect(Collectors.toList()),
+                            false)
+                                    .build(apiVersion);
+                }
+                else {
+                    throw new IllegalStateException();
+                }
+                break;
+            case FIND_COORDINATOR:
+                req = new FindCoordinatorRequest.Builder((FindCoordinatorRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case JOIN_GROUP:
+                req = new JoinGroupRequest((JoinGroupRequestData) reqBody, apiVersion);
+                break;
+            case HEARTBEAT:
+                req = new HeartbeatRequest.Builder((HeartbeatRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case LEAVE_GROUP:
+                LeaveGroupRequestData data = (LeaveGroupRequestData) reqBody;
+                req = new LeaveGroupRequest.Builder(data.groupId(), data.members())
+                        .build(apiVersion);
+                break;
+            case SYNC_GROUP:
+                req = new SyncGroupRequest((SyncGroupRequestData) reqBody, apiVersion);
+                break;
+            case DESCRIBE_GROUPS:
+                req = new DescribeGroupsRequest.Builder((DescribeGroupsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case LIST_GROUPS:
+                req = new ListGroupsRequest((ListGroupsRequestData) reqBody, apiVersion);
+                break;
+            case API_VERSIONS:
+                req = new ApiVersionsRequest((ApiVersionsRequestData) reqBody, apiVersion);
+                break;
+            case CREATE_TOPICS:
+                req = new CreateTopicsRequest((CreateTopicsRequestData) reqBody, apiVersion);
+                break;
+            case DELETE_TOPICS:
+                req = new DeleteTopicsRequest.Builder((DeleteTopicsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case DELETE_RECORDS:
+                req = new DeleteRecordsRequest.Builder((DeleteRecordsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case INIT_PRODUCER_ID:
+                req = new InitProducerIdRequest.Builder((InitProducerIdRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case OFFSET_FOR_LEADER_EPOCH:
+                req = new OffsetsForLeaderEpochRequest((OffsetForLeaderEpochRequestData) reqBody, apiVersion);
+                break;
+            case ADD_PARTITIONS_TO_TXN:
+                req = new AddPartitionsToTxnRequest((AddPartitionsToTxnRequestData) reqBody, apiVersion);
+                break;
+            case ADD_OFFSETS_TO_TXN:
+                req = new AddOffsetsToTxnRequest((AddOffsetsToTxnRequestData) reqBody, apiVersion);
+                break;
+            case END_TXN:
+                req = new EndTxnRequest.Builder((EndTxnRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case WRITE_TXN_MARKERS:
+                req = new WriteTxnMarkersRequest.Builder((WriteTxnMarkersRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case TXN_OFFSET_COMMIT:
+                req = new TxnOffsetCommitRequest((TxnOffsetCommitRequestData) reqBody, apiVersion);
+                break;
+            case DESCRIBE_ACLS:
+                DescribeAclsRequestData d = (DescribeAclsRequestData) reqBody;
+                req = new DescribeAclsRequest.Builder(new AclBindingFilter(
+                        new ResourcePatternFilter(
+                                ResourceType.fromCode(d.resourceTypeFilter()),
+                                d.resourceNameFilter(),
+                                PatternType.fromCode(d.patternTypeFilter())),
+                        new AccessControlEntryFilter(
+                                d.principalFilter(),
+                                d.hostFilter(),
+                                AclOperation.fromCode(d.operation()),
+                                AclPermissionType.fromCode(d.permissionType()))))
+                                        .build(apiVersion);
+                break;
+            case CREATE_ACLS:
+                req = new CreateAclsRequest.Builder((CreateAclsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case DELETE_ACLS:
+                req = new DeleteAclsRequest.Builder((DeleteAclsRequestData) reqBody).build(apiVersion);
+                break;
+            case DESCRIBE_CONFIGS:
+                req = new DescribeConfigsRequest((DescribeConfigsRequestData) reqBody, apiVersion);
+                break;
+            case ALTER_CONFIGS:
+                req = new AlterConfigsRequest((AlterConfigsRequestData) reqBody, apiVersion);
+                break;
+            case ALTER_REPLICA_LOG_DIRS:
+                req = new AlterReplicaLogDirsRequest((AlterReplicaLogDirsRequestData) reqBody, apiVersion);
+                break;
+            case DESCRIBE_LOG_DIRS:
+                req = new DescribeLogDirsRequest((DescribeLogDirsRequestData) reqBody, apiVersion);
+                break;
+            case CREATE_PARTITIONS:
+                req = new CreatePartitionsRequest.Builder((CreatePartitionsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case CREATE_DELEGATION_TOKEN:
+                req = new CreateDelegationTokenRequest.Builder((CreateDelegationTokenRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case RENEW_DELEGATION_TOKEN:
+                req = new RenewDelegationTokenRequest.Builder((RenewDelegationTokenRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case EXPIRE_DELEGATION_TOKEN:
+                req = new ExpireDelegationTokenRequest.Builder((ExpireDelegationTokenRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case DESCRIBE_DELEGATION_TOKEN:
+                DescribeDelegationTokenRequestData tokenRequestData = (DescribeDelegationTokenRequestData) reqBody;
+                req = new DescribeDelegationTokenRequest.Builder(
+                        tokenRequestData.owners().stream().map(o -> new KafkaPrincipal(o.principalType(), o.principalName())).collect(Collectors.toList()))
+                                .build(apiVersion);
+                break;
+            case DELETE_GROUPS:
+                req = new DeleteGroupsRequest((DeleteGroupsRequestData) reqBody, apiVersion);
+                break;
+            case ELECT_LEADERS:
+                ElectLeadersRequestData electLeaders = (ElectLeadersRequestData) reqBody;
+                req = new ElectLeadersRequest.Builder(
+                        ElectionType.valueOf(electLeaders.electionType()),
+                        electLeaders.topicPartitions().stream().flatMap(
+                                t -> t.partitions().stream().map(
+                                        p -> new TopicPartition(t.topic(), p)))
+                                .collect(Collectors.toList()),
+                        electLeaders.timeoutMs())
+                                .build(apiVersion);
+                break;
+            case INCREMENTAL_ALTER_CONFIGS:
+                req = new IncrementalAlterConfigsRequest((IncrementalAlterConfigsRequestData) reqBody, apiVersion);
+                break;
+            case ALTER_PARTITION_REASSIGNMENTS:
+                req = new AlterPartitionReassignmentsRequest.Builder((AlterPartitionReassignmentsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case LIST_PARTITION_REASSIGNMENTS:
+                req = new ListPartitionReassignmentsRequest.Builder((ListPartitionReassignmentsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case OFFSET_DELETE:
+                req = new OffsetDeleteRequest((OffsetDeleteRequestData) reqBody, apiVersion);
+                break;
+            case DESCRIBE_CLIENT_QUOTAS:
+                req = new DescribeClientQuotasRequest((DescribeClientQuotasRequestData) reqBody, apiVersion);
+                break;
+            case ALTER_CLIENT_QUOTAS:
+                req = new AlterClientQuotasRequest((AlterClientQuotasRequestData) reqBody, apiVersion);
+                break;
+            case DESCRIBE_USER_SCRAM_CREDENTIALS:
+                req = new DescribeUserScramCredentialsRequest.Builder((DescribeUserScramCredentialsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case ALTER_USER_SCRAM_CREDENTIALS:
+                req = new AlterUserScramCredentialsRequest.Builder((AlterUserScramCredentialsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case DESCRIBE_QUORUM:
+                req = new DescribeClientQuotasRequest((DescribeClientQuotasRequestData) reqBody, apiVersion);
+                break;
+            case ALTER_PARTITION:
+                req = new AlterPartitionRequest((AlterPartitionRequestData) reqBody, apiVersion);
+                break;
+            case UPDATE_FEATURES:
+                req = new UpdateFeaturesRequest((UpdateFeaturesRequestData) reqBody, apiVersion);
+                break;
+            case DESCRIBE_CLUSTER:
+                req = new DescribeClusterRequest((DescribeClusterRequestData) reqBody, apiVersion);
+                break;
+            case DESCRIBE_PRODUCERS:
+                req = new DescribeProducersRequest.Builder((DescribeProducersRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case DESCRIBE_TRANSACTIONS:
+                req = new DescribeTransactionsRequest.Builder((DescribeTransactionsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case LIST_TRANSACTIONS:
+                req = new ListTransactionsRequest.Builder((ListTransactionsRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case ALLOCATE_PRODUCER_IDS:
+                req = new AllocateProducerIdsRequest((AllocateProducerIdsRequestData) reqBody, apiVersion);
+                break;
+            case VOTE:
+                req = new VoteRequest.Builder((VoteRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case BEGIN_QUORUM_EPOCH:
+                req = new BeginQuorumEpochRequest.Builder((BeginQuorumEpochRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case END_QUORUM_EPOCH:
+                req = new EndQuorumEpochRequest.Builder((EndQuorumEpochRequestData) reqBody)
+                        .build(apiVersion);
+                break;
+            case ENVELOPE:
+                req = new EnvelopeRequest((EnvelopeRequestData) reqBody, apiVersion);
+                break;
+            case FETCH_SNAPSHOT:
+                req = new FetchSnapshotRequest((FetchSnapshotRequestData) reqBody, apiVersion);
+                break;
+            case LEADER_AND_ISR:
+                LeaderAndIsrRequestData lisr = (LeaderAndIsrRequestData) reqBody;
+                req = new LeaderAndIsrRequest.Builder(apiVersion, lisr.controllerId(),
+                        lisr.controllerEpoch(), lisr.brokerEpoch(),
+                        lisr.ungroupedPartitionStates(),
+                        lisr.topicStates().stream().collect(Collectors.toMap(
+                                LeaderAndIsrRequestData.LeaderAndIsrTopicState::topicName,
+                                LeaderAndIsrRequestData.LeaderAndIsrTopicState::topicId)),
+                        lisr.liveLeaders().stream().map(
+                                x -> new Node(
+                                        x.brokerId(),
+                                        x.hostName(),
+                                        x.port()))
+                                .collect(Collectors.toList()))
+                                        .build(apiVersion);
+                break;
+            case STOP_REPLICA:
+                StopReplicaRequestData stopReplica = (StopReplicaRequestData) reqBody;
+                req = new StopReplicaRequest.Builder(apiVersion,
+                        stopReplica.controllerId(),
+                        stopReplica.controllerEpoch(),
+                        stopReplica.brokerEpoch(),
+                        stopReplica.deletePartitions(),
+                        stopReplica.topicStates())
+                                .build(apiVersion);
+                break;
+            case UPDATE_METADATA:
+                req = new UpdateFeaturesRequest((UpdateFeaturesRequestData) reqBody, apiVersion);
+                break;
+            case CONTROLLED_SHUTDOWN:
+                req = new ControlledShutdownRequest.Builder((ControlledShutdownRequestData) reqBody, apiVersion)
+                        .build(apiVersion);
+                break;
+            case BROKER_REGISTRATION:
+                req = new BrokerRegistrationRequest((BrokerRegistrationRequestData) reqBody, apiVersion);
+                break;
+            case BROKER_HEARTBEAT:
+                req = new BrokerHeartbeatRequest((BrokerHeartbeatRequestData) reqBody, apiVersion);
+                break;
+            case UNREGISTER_BROKER:
+                req = new UnregisterBrokerRequest((UnregisterBrokerRequestData) reqBody, apiVersion);
+                break;
             default:
                 throw new IllegalStateException();
         }
-        return body;
+        return req.getErrorResponse(error).data();
     }
 
     private void onSaslHandshakeRequest(ChannelHandlerContext ctx,

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -319,15 +319,17 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
     @VisibleForTesting
     State lastSeen;
 
-    public KafkaAuthnHandler(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
-        this(State.START, mechanismHandlers);
+    public KafkaAuthnHandler(Channel ch,
+                             Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this(ch, State.START, mechanismHandlers);
     }
 
     @VisibleForTesting
-    KafkaAuthnHandler(State init,
+    KafkaAuthnHandler(Channel ch,
+                      State init,
                       Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
         this.lastSeen = init;
-        LOG.debug("Initial state {}", lastSeen);
+        LOG.debug("{}: Initial state {}", ch, lastSeen);
         this.mechanismHandlers = mechanismHandlers.entrySet().stream().collect(Collectors.toMap(
                 e -> e.getKey().mechanismName(), Map.Entry::getValue));
         this.enabledMechanisms = List.copyOf(this.mechanismHandlers.keySet());

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import org.apache.kafka.common.errors.IllegalSaslStateException;
+import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.errors.UnsupportedSaslMechanismException;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.authenticator.SaslInternalConfigs;
+import org.apache.kafka.common.security.plain.internals.PlainSaslServerProvider;
+import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+import org.apache.kafka.common.security.scram.internals.ScramSaslServerProvider;
+
+import io.kroxylicious.proxy.frame.BareSaslRequest;
+import io.kroxylicious.proxy.frame.BareSaslResponse;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * <p>A Netty handler that allows the proxy
+ * to perform the Kafka SASL authentication exchanges needed by
+ * a client connection, specifically {@code SaslHandshake},
+ * and {@code SaslAuthenticate}.</p>
+ *
+ * <p>See the doc for {@link State} for a detailed state machine.</p>
+ *
+ * <p>Client software and authorization information thus obtained is propagated via
+ * an {@link AuthenticationEvent} to upstream handlers, specifically {@link KafkaProxyFrontendHandler}, to use in
+ * deciding how the connection to an upstream connection should be made.</p>
+ *
+ * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=51809888">KIP-12: Kafka Sasl/Kerberos and SSL implementation</a>
+ * added support for Kerberos authentication"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-43%3A+Kafka+SASL+enhancements">KIP-43: Kafka SASL enhancements</a>
+ * added the SaslHandshake RPC in Kafka 0.10.0.0"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-84%3A+Support+SASL+SCRAM+mechanisms">KIP-84: Support SASL SCRAM mechanisms</a>
+ * added support for the SCRAM-SHA-256 and SCRAM-SHA-512 mechanisms"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-152+-+Improve+diagnostics+for+SASL+authentication+failures">KIP-152: Improve diagnostics for SASL authentication failures</a>
+ * added support for the SaslAuthenticate RPC (previously the auth bytes were not encapsulated in a Kafka frame"
+ * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876">KIP-255: OAuth Authentication via SASL/OAUTHBEARER</a>
+ * added support for OAUTH authentication"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate">KIP-365: Allow SASL Connections to Periodically Re-Authenticate</a>
+ * added time-based reauthentication requirements for clients"
+ * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-684+-+Support+mutual+TLS+authentication+on+SASL_SSL+listeners">KIP-684: Support mTLS authentication on SASL_SSL listeners</a>
+ * added support for mutual TLS authentication even on SASL_SSL listeners (which was previously ignored)"
+ */
+public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
+
+    static {
+        PlainSaslServerProvider.initialize();
+        ScramSaslServerProvider.initialize();
+    }
+
+    /**
+     * Represents a state in the {@link KafkaAuthnHandler} state machine.
+     * <pre><code>
+     *                            START
+     *                              │
+     *       ╭────────────────┬─────┴───────╮───────────────╮
+     *       │                │             │               │
+     *       ↓                ↓             │               ↓
+     * API_VERSIONS ──→ SASL_HANDSHAKE_v0 ══╪══⇒ unframed_SASL_AUTHENTICATE
+     *   │      │                           │                     │
+     *   │      │             ╭─────────────╯                     │
+     *   │      │             ↓                                   │
+     *   │      ╰───→ SASL_HANDSHAKE_v1+ ──→ SASL_AUTHENTICATE    │
+     *   │                                         │              ↓
+     *   ╰─────────────────────────────────────────╰─────→ UPSTREAM_CONNECT
+     * </code></pre>
+     * <ul>
+     * <li>API_VERSIONS if optional within the Kafka protocol</li>
+     * <li>SASL authentication may or may not be in use</li>
+     * </ul>
+     */
+    enum State {
+        START,
+        API_VERSIONS,
+        SASL_HANDSHAKE_v0,
+        SASL_HANDSHAKE_v1_PLUS,
+        UNFRAMED_SASL_AUTHENTICATE,
+        FRAMED_SASL_AUTHENTICATE,
+        FAILED,
+        AUTHN_SUCCESS
+    }
+
+    public enum SaslMechanism {
+        PLAIN("PLAIN", null),
+        SCRAM_SHA_256("SCRAM-SHA-256",
+                ScramMechanism.SCRAM_SHA_256,
+                SaslInternalConfigs.CREDENTIAL_LIFETIME_MS_SASL_NEGOTIATED_PROPERTY_KEY),
+        SCRAM_SHA_512("SCRAM-SHA-512", ScramMechanism.SCRAM_SHA_512,
+                SaslInternalConfigs.CREDENTIAL_LIFETIME_MS_SASL_NEGOTIATED_PROPERTY_KEY);
+
+        // TODO support OAUTHBEARER, GSSAPI
+        private final String name;
+        private final ScramMechanism scramMechanism;
+        private final String[] negotiableProperties;
+
+        private SaslMechanism(String saslName, ScramMechanism scramMechanism,
+                              String... negotiableProperties) {
+            this.name = saslName;
+            this.scramMechanism = scramMechanism;
+            this.negotiableProperties = negotiableProperties;
+        }
+
+        public String mechanismName() {
+            return name;
+        }
+
+        static SaslMechanism fromMechanismName(String mechanismName) {
+            switch (mechanismName) {
+                case "PLAIN":
+                    return PLAIN;
+                case "SCRAM-SHA-256":
+                    return SCRAM_SHA_256;
+                case "SCRAM-SHA-512":
+                    return SCRAM_SHA_512;
+            }
+            throw new UnsupportedSaslMechanismException(mechanismName);
+        }
+
+        public ScramMechanism scramMechanism() {
+            return scramMechanism;
+        }
+
+        public String[] negotiableProperties() {
+            return negotiableProperties;
+        }
+    }
+
+    // TODO need some way to support SaslAuthenticate v0, which doesn't use Kafka protcol framing at all
+
+    private final List<String> enabledMechanisms;
+
+    @VisibleForTesting
+    SaslServer saslServer;
+
+    private final Map<String, AuthenticateCallbackHandler> mechanismHandlers;
+
+    @VisibleForTesting
+    State lastSeen;
+
+    public KafkaAuthnHandler(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this(State.START, mechanismHandlers);
+    }
+
+    @VisibleForTesting
+    KafkaAuthnHandler(State init,
+                      Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this.lastSeen = init;
+        this.mechanismHandlers = mechanismHandlers.entrySet().stream().collect(Collectors.toMap(
+                e -> e.getKey().mechanismName(), Map.Entry::getValue));
+        this.enabledMechanisms = List.copyOf(this.mechanismHandlers.keySet());
+    }
+
+    private InvalidRequestException illegalTransition(State next) {
+        lastSeen = State.FAILED;
+        return new InvalidRequestException("Illegal state transition from " + lastSeen + " to " + next);
+    }
+
+    private void validateTransition(State next) {
+        State previous = lastSeen;
+        switch (next) {
+            case API_VERSIONS:
+                if (previous != State.START) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case SASL_HANDSHAKE_v0:
+            case SASL_HANDSHAKE_v1_PLUS:
+                if (previous != State.START
+                        && previous != State.API_VERSIONS) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case UNFRAMED_SASL_AUTHENTICATE:
+                if (previous != State.START
+                        && previous != State.SASL_HANDSHAKE_v0
+                        && previous != State.UNFRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case FRAMED_SASL_AUTHENTICATE:
+                if (previous != State.SASL_HANDSHAKE_v1_PLUS
+                        && previous != State.FRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case AUTHN_SUCCESS:
+                if (previous != State.FRAMED_SASL_AUTHENTICATE
+                        && previous != State.UNFRAMED_SASL_AUTHENTICATE) {
+                    throw illegalTransition(next);
+                }
+                break;
+            case FAILED:
+                break;
+            default:
+                throw illegalTransition(next);
+        }
+        lastSeen = next;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof BareSaslRequest) {
+            var bareSaslRequest = (BareSaslRequest) msg;
+            if (supportsSaslGssApi() && (lastSeen == State.START
+                    || lastSeen == State.API_VERSIONS)) {
+                ctx.writeAndFlush(new BareSaslResponse(doEvaluateResponse(ctx, bareSaslRequest.bytes())));
+            }
+            else if (lastSeen == State.SASL_HANDSHAKE_v0
+                    || lastSeen == State.UNFRAMED_SASL_AUTHENTICATE) {
+                validateTransition(State.UNFRAMED_SASL_AUTHENTICATE);
+                // delegate to the SASL code to read the bytes directly
+                ctx.writeAndFlush(new BareSaslResponse(doEvaluateResponse(ctx, bareSaslRequest.bytes())));
+            }
+            else {
+                lastSeen = State.FAILED;
+                throw new InvalidRequestException("Bare SASL bytes without GSSAPI support or prior SaslHandshake");
+            }
+        }
+        else if (msg instanceof DecodedRequestFrame) {
+            DecodedRequestFrame<?> frame = (DecodedRequestFrame<?>) msg;
+            {
+                switch (frame.apiKey()) {
+                    case API_VERSIONS:
+                        validateTransition(State.API_VERSIONS);
+                        ctx.fireChannelRead(frame);
+                        return;
+                    case SASL_HANDSHAKE:
+                        validateTransition(frame.apiVersion() == 0 ? State.SASL_HANDSHAKE_v0 : State.SASL_HANDSHAKE_v1_PLUS);
+                        onSaslHandshakeRequest(ctx, (DecodedRequestFrame<SaslHandshakeRequestData>) frame);
+                        return;
+                    case SASL_AUTHENTICATE:
+                        validateTransition(State.FRAMED_SASL_AUTHENTICATE);
+                        onSaslAuthenticateRequest(ctx, (DecodedRequestFrame<SaslAuthenticateRequestData>) frame);
+                        return;
+                    default:
+                        if (lastSeen == State.AUTHN_SUCCESS) {
+                            ctx.fireChannelRead(msg);
+                        }
+                        else {
+                            ctx.writeAndFlush(
+                                    new DecodedResponseFrame<>(
+                                            frame.apiVersion(),
+                                            frame.correlationId(),
+                                            new ResponseHeaderData().setCorrelationId(frame.correlationId()),
+                                            errorResponse(frame, new IllegalSaslStateException("Nope"))
+                                    // TODO add support for session lifetime/reauth
+                                    ));
+                        }
+                }
+            }
+        }
+        else {
+            throw new IllegalStateException("Unexpected message " + msg.getClass());
+        }
+    }
+
+    private ApiMessage errorResponse(DecodedRequestFrame<?> frame, Throwable error) {
+        ApiMessage body;
+        switch (frame.apiKey()) {
+            case METADATA:
+                body = new MetadataRequest((MetadataRequestData) frame.body(), frame.apiVersion()).getErrorResponse(0, error).data();
+                break;
+            // TODO all the other cases!
+            default:
+                throw new IllegalStateException();
+        }
+        return body;
+    }
+
+    private void onSaslHandshakeRequest(ChannelHandlerContext ctx,
+                                        DecodedRequestFrame<SaslHandshakeRequestData> data)
+            throws SaslException {
+        String mechanism = data.body().mechanism();
+        Errors error;
+        if (lastSeen == State.AUTHN_SUCCESS) {
+            error = Errors.ILLEGAL_SASL_STATE;
+        }
+        else if (enabledMechanisms.contains(mechanism)) {
+            var cbh = mechanismHandlers.get(mechanism);
+            // TODO use SNI to supply the correct hostname
+            saslServer = Sasl.createSaslServer(mechanism, "kafka", null, null, cbh);
+            if (saslServer == null) {
+                throw new IllegalStateException("SASL mechanism had no providers: " + mechanism);
+            }
+            else {
+                error = Errors.NONE;
+            }
+        }
+        else {
+            error = Errors.UNSUPPORTED_SASL_MECHANISM;
+        }
+
+        ctx.writeAndFlush(new DecodedResponseFrame<>(
+                data.apiVersion(),
+                data.correlationId(),
+                new ResponseHeaderData().setCorrelationId(data.correlationId()),
+                new SaslHandshakeResponseData()
+                        .setMechanisms(enabledMechanisms)
+                        .setErrorCode(error.code())));
+
+    }
+
+    private void onSaslAuthenticateRequest(ChannelHandlerContext ctx,
+                                           DecodedRequestFrame<SaslAuthenticateRequestData> data) {
+        byte[] bytes = new byte[0];
+        Errors error;
+        String errorMessage;
+
+        try {
+            bytes = doEvaluateResponse(ctx, data.body().authBytes());
+            error = Errors.NONE;
+            errorMessage = null;
+        }
+        catch (SaslAuthenticationException e) {
+            error = Errors.SASL_AUTHENTICATION_FAILED;
+            errorMessage = e.getMessage();
+        }
+        catch (SaslException e) {
+            error = Errors.SASL_AUTHENTICATION_FAILED;
+            errorMessage = "An error occurred";
+        }
+
+        ctx.writeAndFlush(
+                new DecodedResponseFrame<>(
+                        data.apiVersion(),
+                        data.correlationId(),
+                        new ResponseHeaderData().setCorrelationId(data.correlationId()),
+                        new SaslAuthenticateResponseData()
+                                .setErrorCode(error.code())
+                                .setErrorMessage(errorMessage)
+                                .setAuthBytes(bytes)
+                // TODO add support for session lifetime
+                ));
+    }
+
+    private boolean supportsSaslGssApi() {
+        return false;
+    }
+
+    private byte[] doEvaluateResponse(ChannelHandlerContext ctx,
+                                      byte[] authBytes)
+            throws SaslException {
+        final byte[] bytes;
+        try {
+            bytes = saslServer.evaluateResponse(authBytes);
+        }
+        catch (SaslAuthenticationException e) {
+            validateTransition(State.FAILED);
+            saslServer.dispose();
+            throw e;
+        }
+        catch (Exception e) {
+            validateTransition(State.FAILED);
+            saslServer.dispose();
+            throw new SaslAuthenticationException(e.getMessage());
+        }
+
+        if (saslServer.isComplete()) {
+            validateTransition(State.AUTHN_SUCCESS);
+            String authorizationId = saslServer.getAuthorizationID();
+            String[] properties = SaslMechanism.fromMechanismName(saslServer.getMechanismName()).negotiableProperties();
+            Map<String, Object> negotiatedProperty = new HashMap<>((int) (properties.length * 4.0 / 3));
+            for (String property : properties) {
+                Object value = saslServer.getNegotiatedProperty(property);
+                if (value != null) {
+                    negotiatedProperty.put(property, value);
+                }
+            }
+            saslServer.dispose();
+            ctx.fireUserEventTriggered(new AuthenticationEvent(authorizationId,
+                    negotiatedProperty));
+
+        }
+        return bytes;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -62,7 +62,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         if (logFrames) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));
         }
-
+        
         pipeline.addLast("frontendHandler", new KafkaProxyFrontendHandler(remoteHost,
                 remotePort,
                 correlation,

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -1,0 +1,549 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.errors.InvalidRequestException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.authenticator.CredentialCache;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandler;
+import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
+import org.apache.kafka.common.security.scram.internals.ScramMessages;
+import org.apache.kafka.common.security.scram.internals.ScramServerCallbackHandler;
+import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.frame.BareSaslRequest;
+import io.kroxylicious.proxy.frame.BareSaslResponse;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.codec.CorrelationManager;
+import io.kroxylicious.proxy.internal.future.PromiseImpl;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class KafkaAuthnHandlerTest {
+
+    public static final String CLIENT_SOFTWARE_NAME = "my-test-client";
+    public static final String CLIENT_SOFTWARE_VERSION = "1.0.0";
+    EmbeddedChannel channel = new EmbeddedChannel();
+    private final CorrelationManager correlationManager = new CorrelationManager();
+    private int corrId = 0;
+    private UserEventCollector userEventCollector;
+    private KafkaAuthnHandler kafkaAuthnHandler;
+
+    private void buildChannel(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        channel = new EmbeddedChannel();
+        kafkaAuthnHandler = new KafkaAuthnHandler(
+                KafkaAuthnHandler.State.START, mechanismHandlers);
+        channel.pipeline().addLast(kafkaAuthnHandler);
+        userEventCollector = new UserEventCollector();
+        channel.pipeline().addLast(userEventCollector);
+    }
+
+    @AfterEach
+    public void after() {
+        channel.checkException();
+    }
+
+    static Iterable<Short> rangeClosed(short lowerInclusive, short upperInclusive) {
+        Stream<Short> range = IntStream.rangeClosed(lowerInclusive, upperInclusive).boxed().map(Integer::shortValue);
+        range = Stream.concat(Stream.of((Short) null), range);
+        return range.collect(Collectors.toList());
+    }
+
+    static class RequestVersions {
+        // apiVersionsVersion == null => omit ApiVersions request
+        private final Short apiVersionsVersion;
+        // saslHandshakeVersion == null => omit SaslHandshake
+        private final Short saslHandshakeVersion;
+        // saslAuthenticateVersion == null => use a base SASL request (no kafka header)
+        private final Short saslAuthenticateVersion;
+
+        public RequestVersions(Short apiVersionsVersion, Short saslHandshakeVersion, Short saslAuthenticateVersion) {
+            this.apiVersionsVersion = apiVersionsVersion;
+            this.saslHandshakeVersion = saslHandshakeVersion;
+            this.saslAuthenticateVersion = saslAuthenticateVersion;
+        }
+
+        boolean useBare() {
+            return saslAuthenticateVersion == null;
+        }
+
+        boolean sendApiVersions() {
+            return apiVersionsVersion != null;
+        }
+
+        boolean sendHandshake() {
+            return saslHandshakeVersion != null;
+        }
+
+        /**
+         * KIP-152 says: "the new SaslAuthenticate requests will be used only if
+         * SaslHandshake v1 is used to initiate handshake."
+         * however we want to test the state machine even for broker/malicious clients
+         * that don't follow the spec. i.e.
+         * 1. SaslHandshake v0 followed by SaslAuthenticate
+         * 2. No SaslHandshake followed by SaslAuthenticate
+         */
+        boolean expectValidBareAuthenticateRequest() {
+            return (saslHandshakeVersion == null || saslHandshakeVersion == 0);
+        }
+
+        boolean expectGssUnsupported() {
+            return (saslHandshakeVersion == null && saslAuthenticateVersion == null);
+        }
+
+        boolean expectValidFramedAuthenticateRequest() {
+            return saslHandshakeVersion != null && saslHandshakeVersion >= 1;
+        }
+
+        @Override
+        public String toString() {
+            return "RequestVersions(" +
+                    "apiVersionsVersion=" + (apiVersionsVersion == null ? "omitted" : apiVersionsVersion) +
+                    ", saslHandshakeVersion=" + (saslHandshakeVersion == null ? "omitted" : saslHandshakeVersion) +
+                    ", saslAuthenticateVersion=" + (saslAuthenticateVersion == null ? "unframed" : "v" + saslAuthenticateVersion) +
+                    ')';
+        }
+    }
+
+    public static List<Object[]> apiVersions() {
+        var result = new ArrayList<Object[]>();
+
+        for (Short apiVersionsVersion : rangeClosed(ApiVersionsRequestData.LOWEST_SUPPORTED_VERSION, ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION)) {
+            for (Short handshakeVersion : rangeClosed(SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION, SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)) {
+                for (Short authenticateVersion : rangeClosed(SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION, SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)) {
+
+                    result.add(new Object[]{ new RequestVersions(apiVersionsVersion, handshakeVersion, authenticateVersion) });
+                }
+            }
+        }
+        return result;
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSaslPlainSuccessfulAuth(RequestVersions versions) {
+        doSaslPlain(versions,
+                "fred", "foo",
+                "fred", "foo");
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSaslPlainWrongPassword(RequestVersions versions) {
+        doSaslPlain(versions,
+                "fred", "foo",
+                "fred", "bar");
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSaslPlainUnknownUser(RequestVersions versions) {
+        doSaslPlain(versions,
+                "fred", "foo",
+                "bob", "foo");
+    }
+
+    private void doSaslPlain(
+                             RequestVersions versions,
+                             String configuredUser,
+                             String configuredPassword,
+                             String authenticatingUser,
+                             String authenticatingPassword) {
+
+        buildChannel(Map.of(KafkaAuthnHandler.SaslMechanism.PLAIN, saslPlainCallbackHandler(configuredUser, configuredPassword)));
+
+        if (versions.sendApiVersions()) {
+            // ApiVersions should propagate
+            doSendApiVersions(versions);
+
+            // We don't expect an ApiVersions response, because there is no handler in the pipeline
+            // which will send one
+        }
+
+        // Other requests should be denied prior to successful authentication
+        assertMetadataDenied();
+
+        if (versions.sendHandshake()) {
+            doSendHandshake("PLAIN", versions);
+        }
+
+        final boolean expectSuccess = configuredUser.equals(authenticatingUser)
+                && configuredPassword.equals(authenticatingPassword)
+                && (versions.useBare() && versions.expectValidBareAuthenticateRequest()
+                        && !versions.expectGssUnsupported() || !versions.useBare() && versions.expectValidFramedAuthenticateRequest());
+        // Prior to KIP-152 and the use of SaslAuthenticate responses
+        // there was no way to communicate failure back to clients so the server-size
+        // SASL code had the throw
+        final boolean expectException = versions.useBare();
+        byte[] saslBytes = (authenticatingUser + "\0" + authenticatingUser + "\0" + authenticatingPassword).getBytes(StandardCharsets.UTF_8);
+        try {
+            byte[] responseBytes = doSendAuthenticate(versions, expectSuccess, expectException, saslBytes);
+            if (responseBytes != null) {
+                assertEquals(0, responseBytes.length);
+            }
+        }
+        catch (SaslAuthenticationException e) {
+            assertTrue(expectException,
+                    e + " thrown when expecting successful authentication");
+            // TODO assert FAILED state, no event propagated, further transitions impossible
+            // subsequent events not passed upstream
+            assertEquals(KafkaAuthnHandler.State.FAILED, kafkaAuthnHandler.lastSeen);
+            return;
+        }
+
+        if (expectSuccess) {
+            assertAuthnSuccess();
+        }
+        else {
+            assertAuthnFailure(versions);
+        }
+
+    }
+
+    private byte[] doSendAuthenticate(RequestVersions versions,
+                                      boolean expectSuccess,
+                                      boolean expectException,
+                                      byte[] saslBytes) {
+        byte[] responseBytes;
+        if (versions.useBare()) {
+            var bare = new BareSaslRequest(saslBytes, true);
+            if (versions.expectValidBareAuthenticateRequest()
+                    && !versions.expectGssUnsupported()) {
+                channel.writeInbound(bare);
+                BareSaslResponse response = assertInstanceOf(BareSaslResponse.class, channel.readOutbound());
+                responseBytes = response.bytes();
+            }
+            else {
+                var msg = assertThrows(InvalidRequestException.class, () -> channel.writeInbound(bare)).getMessage();
+                if (versions.expectGssUnsupported()) {
+                    assertEquals("Bare SASL bytes without GSSAPI support or prior SaslHandshake", msg);
+                }
+                else {
+                    assertEquals("Bare SASL bytes without GSSAPI support or prior SaslHandshake", msg);
+                }
+                // TODO assertions that the handler is unusable
+                // return;
+                responseBytes = null;
+            }
+        }
+        else {
+            SaslAuthenticateRequestData authenticateRequest = new SaslAuthenticateRequestData()
+                    .setAuthBytes(saslBytes);
+            if (versions.expectValidFramedAuthenticateRequest()) {
+                writeRequest(versions.saslAuthenticateVersion, authenticateRequest);
+                if (expectException) {
+                    fail("Unexpected response");
+                }
+                SaslAuthenticateResponseData saslAuthenticateResponseData = readResponse(SaslAuthenticateResponseData.class);
+                if (expectSuccess) {
+                    assertErrorCode(Errors.NONE, saslAuthenticateResponseData.errorCode());
+                }
+                else {
+                    assertErrorCode(Errors.SASL_AUTHENTICATION_FAILED, saslAuthenticateResponseData.errorCode());
+                }
+                responseBytes = saslAuthenticateResponseData.authBytes();
+            }
+            else {
+                assertThrows(InvalidRequestException.class, () -> writeRequest(versions.saslAuthenticateVersion, authenticateRequest));
+                // TODO assertions that the handler is unusable
+                // return;
+                responseBytes = null;
+            }
+        }
+        return responseBytes;
+    }
+
+    private PlainServerCallbackHandler saslPlainCallbackHandler(String user,
+                                                                String password) {
+        PlainServerCallbackHandler plainServerCallbackHandler = new PlainServerCallbackHandler();
+        plainServerCallbackHandler.configure(Map.of(),
+                KafkaAuthnHandler.SaslMechanism.PLAIN.mechanismName(),
+                List.of(new AppConfigurationEntry(PlainLoginModule.class.getName(),
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                        Map.of("user_" + user, password))));
+        return plainServerCallbackHandler;
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSaslScramSha256SuccessfulAuth(RequestVersions versions)
+            throws Exception {
+        doSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_256, versions,
+                "fred", "password",
+                "fred", "password");
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSaslScramSha512SuccessfulAuth(RequestVersions versions)
+            throws Exception {
+        doSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_512, versions,
+                "fred", "password",
+                "fred", "password");
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSaslScramSha512WrongPassword(RequestVersions versions)
+            throws Exception {
+        doSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_512, versions,
+                "fred", "password",
+                "fred", "wrongpassword");
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersions")
+    public void testSaslScramSha512UnknownUser(RequestVersions versions)
+            throws Exception {
+        doSaslScramShaAuth(KafkaAuthnHandler.SaslMechanism.SCRAM_SHA_512, versions,
+                "fred", "password",
+                "bob", "password");
+    }
+
+    private void doSaslScramShaAuth(
+                                    KafkaAuthnHandler.SaslMechanism saslMechanism,
+                                    RequestVersions versions,
+                                    String configuredUser, String configuredPassword,
+                                    String authenticatingUser, String authenticatingPassword)
+            throws Exception {
+
+        buildChannel(Map.of(saslMechanism, saslScramShaCallbackHandler(saslMechanism, configuredUser, configuredPassword)));
+
+        if (versions.sendApiVersions()) {
+            doSendApiVersions(versions);
+        }
+
+        // Other requests should be denied
+        assertMetadataDenied();
+
+        if (versions.sendHandshake()) {
+            doSendHandshake(saslMechanism.mechanismName(), versions);
+        }
+
+        final boolean expectFirstMessageSuccess = configuredUser.equals(authenticatingUser)
+                && (versions.useBare() && versions.expectValidBareAuthenticateRequest()
+                        && !versions.expectGssUnsupported() || !versions.useBare() && versions.expectValidFramedAuthenticateRequest());
+
+        final boolean expectSecondMessageSuccess = configuredPassword.equals(authenticatingPassword)
+                && (versions.useBare() && versions.expectValidBareAuthenticateRequest()
+                        && !versions.expectGssUnsupported() || !versions.useBare() && versions.expectValidFramedAuthenticateRequest());
+
+        final boolean expectSuccess = expectFirstMessageSuccess && expectSecondMessageSuccess;
+        final boolean expectException = versions.useBare();
+        try {
+            ScramFormatter scramFormatter = new ScramFormatter(saslMechanism.scramMechanism());
+            // First authenticate
+            ScramMessages.ClientFirstMessage clientFirst = new ScramMessages.ClientFirstMessage(authenticatingUser, scramFormatter.secureRandomString(), Map.of());
+            byte[] saslBytes = clientFirst.toBytes();
+            byte[] responseBytes = doSendAuthenticate(versions, expectFirstMessageSuccess, expectException, saslBytes);
+            if (!configuredUser.equals(authenticatingUser)) {
+                assertAuthnFailure(versions);
+                return;
+            }
+            else if (responseBytes != null) {
+                // assertNotEquals(0, responseBytes.length);
+                ScramMessages.ServerFirstMessage serverFirstMessage = new ScramMessages.ServerFirstMessage(responseBytes);
+
+                // Second authenticate
+                byte[] passwordBytes = ScramFormatter.normalize(new String(authenticatingPassword));
+                var saltedPassword = scramFormatter.hi(passwordBytes, serverFirstMessage.salt(), serverFirstMessage.iterations());
+                ScramMessages.ClientFinalMessage clientFinal = new ScramMessages.ClientFinalMessage("n,,".getBytes(StandardCharsets.UTF_8), serverFirstMessage.nonce());
+                byte[] clientProof = scramFormatter.clientProof(saltedPassword, clientFirst, serverFirstMessage, clientFinal);
+                clientFinal.proof(clientProof);
+
+                byte[] finalBytes = clientFinal.toBytes();
+                doSendAuthenticate(versions, expectSecondMessageSuccess, expectException, finalBytes);
+            }
+        }
+        catch (SaslAuthenticationException e) {
+            assertTrue(expectException,
+                    e + " thrown when expecting successful authentication");
+            // TODO assert FAILED state, no event propagated, further transitions impossible
+            // subsequent events not passed upstream
+            assertEquals(KafkaAuthnHandler.State.FAILED, kafkaAuthnHandler.lastSeen);
+        }
+
+        if (expectSuccess) {
+            assertAuthnSuccess();
+        }
+        else {
+            assertAuthnFailure(versions);
+        }
+
+    }
+
+    private void assertAuthnFailure(RequestVersions versions) {
+        assertEquals(KafkaAuthnHandler.State.FAILED, kafkaAuthnHandler.lastSeen);
+        if (versions.sendHandshake()) {
+            assertFalse(kafkaAuthnHandler.saslServer.isComplete());
+        }
+
+        // Event should be propagated
+        assertNull(userEventCollector.readUserEvent(),
+                "Unexpected authentication event");
+
+        // Subsequent events should not be passed upstream
+        MetadataRequestData metadataRequest = new MetadataRequestData();
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest);
+        assertNull(channel.readInbound(),
+                "Expect RPC following successful authentication to be propagated");
+    }
+
+    private void assertAuthnSuccess() {
+        assertEquals(KafkaAuthnHandler.State.AUTHN_SUCCESS, kafkaAuthnHandler.lastSeen);
+        assertTrue(kafkaAuthnHandler.saslServer.isComplete());
+
+        // Event should be propagated
+        var ae = assertInstanceOf(AuthenticationEvent.class, userEventCollector.readUserEvent(),
+                "Expect authentication event");
+        assertEquals("fred", ae.authorizationId());
+        assertTrue(ae.negotiatedProperties().isEmpty());
+        assertNull(userEventCollector.readUserEvent(), "Expected a single authn event");
+
+        // Subsequent events should be passed upstream
+        MetadataRequestData metadataRequest = new MetadataRequestData();
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest);
+        var followingFrame = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect RPC following successful authentication to be propagated");
+        assertInstanceOf(MetadataRequestData.class, followingFrame.body());
+    }
+
+    private void doSendHandshake(String saslMechanism, RequestVersions versions) {
+        SaslHandshakeRequestData handshakeRequest = new SaslHandshakeRequestData()
+                .setMechanism(saslMechanism);
+        writeRequest(versions.saslHandshakeVersion, handshakeRequest);
+        var handshakeResponseBody = readResponse(SaslHandshakeResponseData.class);
+        assertErrorCode(Errors.NONE, handshakeResponseBody.errorCode());
+    }
+
+    private static void assertErrorCode(Errors error, short errorCode) {
+        assertEquals(error, Errors.forCode(errorCode));
+    }
+
+    private void assertMetadataDenied() {
+        MetadataRequestData metadataRequest1 = new MetadataRequestData();
+        metadataRequest1.topics().add(new MetadataRequestData.MetadataRequestTopic().setName("topic"));
+
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, metadataRequest1);
+        assertNull(channel.readInbound(),
+                "Non-ApiVersions requests should not propagate prior to successful authn");
+        MetadataResponseData metadataResponse1 = readResponse(MetadataResponseData.class);
+        assertErrorCode(Errors.ILLEGAL_SASL_STATE, metadataResponse1.topics().iterator().next().errorCode());
+    }
+
+    private void doSendApiVersions(RequestVersions versions) {
+        // ApiVersions should propagate
+        ApiVersionsRequestData apiVersionsRequest = new ApiVersionsRequestData()
+                .setClientSoftwareName(CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(CLIENT_SOFTWARE_VERSION);
+        writeRequest(versions.apiVersionsVersion, apiVersionsRequest);
+
+        var cse = assertInstanceOf(DecodedRequestFrame.class, channel.readInbound(),
+                "Expect DecodedRequestFrame");
+        assertInstanceOf(ApiVersionsRequestData.class, cse.body(),
+                "Expected ApiVersions request to be propagated to next handler");
+        // We don't expect an ApiVersions response, because there is no handler in the pipeline
+        // which will send one
+    }
+
+    private ScramServerCallbackHandler saslScramShaCallbackHandler(KafkaAuthnHandler.SaslMechanism saslMechanism,
+                                                                   String configuredUser, String configuredPassword) {
+        CredentialCache.Cache<ScramCredential> credentialCache = new CredentialCache.Cache<>(ScramCredential.class);
+        ScramCredential credential;
+        try {
+            credential = new ScramFormatter(saslMechanism.scramMechanism()).generateCredential(configuredPassword, 4096);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        credentialCache.put(configuredUser, credential);
+        ScramServerCallbackHandler callbackHandler = new ScramServerCallbackHandler(credentialCache, new DelegationTokenCache(List.of(saslMechanism.mechanismName())));
+        callbackHandler.configure(null, saslMechanism.mechanismName(), null);
+        return callbackHandler;
+    }
+
+    private <T extends ApiMessage> T readResponse(Class<T> cls) {
+        DecodedResponseFrame<?> authenticateResponseFrame = assertInstanceOf(DecodedResponseFrame.class, channel.readOutbound());
+        return assertInstanceOf(cls, authenticateResponseFrame.body());
+    }
+
+    private void writeRequest(short apiVersion, ApiMessage body) {
+        var apiKey = ApiKeys.forId(body.apiKey());
+
+        int downstreamCorrelationId = corrId++;
+
+        short headerVersion = apiKey.requestHeaderVersion(apiVersion);
+        RequestHeaderData header = new RequestHeaderData()
+                .setRequestApiKey(apiKey.id)
+                .setRequestApiVersion(apiVersion)
+                .setClientId("client-id")
+                .setCorrelationId(downstreamCorrelationId);
+
+        correlationManager.putBrokerRequest(body.apiKey(), apiVersion, downstreamCorrelationId, true, new KrpcFilter() {
+            @Override
+            public void onRequest(DecodedRequestFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+
+            }
+
+            @Override
+            public void onResponse(DecodedResponseFrame<?> decodedFrame, KrpcFilterContext filterContext) {
+
+            }
+
+            @Override
+            public boolean shouldDeserializeResponse(ApiKeys apiKey, short apiVersion) {
+                return true;
+            }
+        }, new PromiseImpl<>(), true);
+
+        channel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
+    }
+
+    // TODO check the unsuccessful authentication case
+    // TODO check the bad password case
+    // TODO check the scram sha mechanisms
+    // TODO check that unexpected state transitions are handled with disconnection
+    // TODO check that unknown read type (like ProxyDecodeEvent) propagate to upstream handlers
+    // TODO SaslGssApi case - bare request down wire first
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.security.scram.internals.ScramMessages;
 import org.apache.kafka.common.security.scram.internals.ScramServerCallbackHandler;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -48,6 +49,7 @@ import io.kroxylicious.proxy.frame.BareSaslRequest;
 import io.kroxylicious.proxy.frame.BareSaslResponse;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.KafkaAuthnHandler.SaslMechanism;
 import io.kroxylicious.proxy.internal.codec.CorrelationManager;
 import io.kroxylicious.proxy.internal.future.PromiseImpl;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -70,9 +72,9 @@ public class KafkaAuthnHandlerTest {
     private UserEventCollector userEventCollector;
     private KafkaAuthnHandler kafkaAuthnHandler;
 
-    private void buildChannel(Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+    private void buildChannel(Map<SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
         channel = new EmbeddedChannel();
-        kafkaAuthnHandler = new KafkaAuthnHandler(
+        kafkaAuthnHandler = new KafkaAuthnHandler(channel,
                 KafkaAuthnHandler.State.START, mechanismHandlers);
         channel.pipeline().addLast(kafkaAuthnHandler);
         userEventCollector = new UserEventCollector();

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/UserEventCollector.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/UserEventCollector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * A ChannelInboundHandlerAdapter which allows asserting which users events were fired
+ * both other prior handlers in a netty pipeline.
+ */
+public class UserEventCollector extends ChannelInboundHandlerAdapter {
+    List<Object> events = new ArrayList<>();
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        Objects.requireNonNull(evt);
+        events.add(evt);
+        super.userEventTriggered(ctx, evt);
+    }
+
+    public Object readUserEvent() {
+        return events.isEmpty() ? null : events.remove(0);
+    }
+
+    public List<Object> userEvents() {
+        return List.of(events);
+    }
+
+    public void clearUserEvents() {
+        events.clear();
+    }
+}


### PR DESCRIPTION
Introduce `KafkaAuthnFilter` which should be configured at the front of the pipeline (after the request decoder) and which intercepts ApiVersions, SaslHandshake and SaslAuthenticate frames in order that the proxy authenticates the remote client.

Currently only SASL-PLAIN and SASL-SCRAM-SHA are supported and there is no easy way of configuring the "user database" (though the test shows how this can be done). We borrow some of the SASL code from Kafka in the implementation.

When authentication is successful a Netty user even (AuthenticationEvent) is fired down the pipeline to later handlers. This is not consumed by any filters in this commit but will be in a later commit.

This commit also introduces the BareSaslRequest and BareSaslResponse. These are to cope with the history of how Kafka handles SASL. Before KIP-152 the SASL bytes where sent down the wire without any Kafka request encapsulation. This doesn't fit nicely with the class hierarchy we have for RequestFrame and ResponseFrame, which assume the presence of Kafka headers. Although BareSaslRequest and BareSaslResponse are used here in the KafkaAuthnFilter, they're not yet supported by the RequestDecoder or ResponseEncoder, and so the proxy continues not to support such old clients with this change.