### PR TITLE
Add NetFilter abstraction for pluggable connection logic 

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>netty-transport-native-unix-common</artifactId>
             <version>${netty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-haproxy</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -96,7 +101,6 @@
             <artifactId>picocli</artifactId>
             <version>4.6.3</version>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -5,12 +5,15 @@
  */
 package io.kroxylicious.proxy;
 
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
+import io.kroxylicious.proxy.internal.filter.SimpleNetFilter;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -103,9 +106,11 @@ public final class KafkaProxy {
         LOGGER.info("Proxying local {} to remote {}",
                 proxyAddress(), brokerAddress());
 
-        KafkaProxyInitializer initializer = new KafkaProxyInitializer(brokerHost,
-                brokerPort,
-                filterChainFactory,
+        KafkaProxyInitializer initializer = new KafkaProxyInitializer(false,
+                Map.of(),
+                new SimpleNetFilter(brokerHost,
+                        brokerPort,
+                        filterChainFactory),
                 logNetwork,
                 logFrames);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
-import io.kroxylicious.proxy.internal.filter.SimpleNetFilter;
+import io.kroxylicious.proxy.internal.filter.FixedNetFilter;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -108,7 +108,7 @@ public final class KafkaProxy {
 
         KafkaProxyInitializer initializer = new KafkaProxyInitializer(false,
                 Map.of(),
-                new SimpleNetFilter(brokerHost,
+                new FixedNetFilter(brokerHost,
                         brokerPort,
                         filterChainFactory),
                 logNetwork,

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
@@ -16,10 +16,10 @@ public interface NetFilter {
     /**
      * Determine the upstream cluster to connect to based on the information
      * provided by the given {@code context},
-     * by invoking {@link NetFilterContext#connect(String, int, KrpcFilter[])}.
+     * by invoking {@link NetFilterContext#initiateConnect(String, int, KrpcFilter[])}.
      * @param context The context.
      */
-    void upstreamBroker(NetFilterContext context);
+    void selectServer(NetFilterContext context);
 
     interface NetFilterContext {
         /**
@@ -61,13 +61,13 @@ public interface NetFilter {
         public String sniHostname();
 
         /**
-         * Connect to the upstream broker at the given {@code host} and {@code port},
+         * Connect to the Kafka server at the given {@code host} and {@code port},
          * using the given protocol filters
          * @param host The host
          * @param port The port
          * @param filters The filters
          */
-        public void connect(String host, int port, KrpcFilter[] filters);
+        public void initiateConnect(String host, int port, KrpcFilter[] filters);
 
         // TODO add API for delayed responses
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
@@ -23,18 +23,23 @@ public interface NetFilter {
 
     interface NetFilterContext {
         /**
-         * @return The address of the client
-         * (possibly not the address of the remote TCP/TLS peer, if any intermediate L4 or
-         * L7 proxy is propagating client connection information).
+         * @return The source host of the client, taking into account source host information
+         * propagated by intermediate proxies.
+         * You can think of this as being like HTTP's {@code X-Forwarded-For} header.
          * @see #srcAddress()
          */
-        public String clientAddress();
+        public String clientHost();
 
+        /**
+         * @return The source port of the client, taking into account source host information
+         * propagated by intermediate proxies.
+         */
         public int clientPort();
 
         /**
-         * @return The address of the remote peer, which may be a proxy or the ultimate client.
-         * @see #clientAddress()
+         * @return The address of the remote TCP peer, which may the ultimate client,
+         * but could be an intermediate proxy.
+         * @see #clientHost()
          */
         public SocketAddress srcAddress();
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/NetFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.filter;
+
+import java.net.SocketAddress;
+
+/**
+ * Abstracts some policy/logic for how an upstream connection for a given client connection
+ * is made.
+ */
+public interface NetFilter {
+
+    /**
+     * Determine the upstream cluster to connect to based on the information
+     * provided by the given {@code context},
+     * by invoking {@link NetFilterContext#connect(String, int, KrpcFilter[])}.
+     * @param context The context.
+     */
+    void upstreamBroker(NetFilterContext context);
+
+    interface NetFilterContext {
+        /**
+         * @return The address of the client
+         * (possibly not the address of the remote TCP/TLS peer, if any intermediate L4 or
+         * L7 proxy is propagating client connection information).
+         * @see #srcAddress()
+         */
+        public String clientAddress();
+
+        public int clientPort();
+
+        /**
+         * @return The address of the remote peer, which may be a proxy or the ultimate client.
+         * @see #clientAddress()
+         */
+        public SocketAddress srcAddress();
+
+        /**
+         * The authorized id, or null if there is no authentication configured for this listener.
+         * @return
+         */
+        public String authorizedId();
+
+        /**
+         * @return The name of the client software, if known via ApiVersions request. Otherwise null.
+         */
+        public String clientSoftwareName();
+
+        /**
+         * @return The version of the client software, if known via ApiVersions request. Otherwise null.
+         */
+        public String clientSoftwareVersion();
+
+        /**
+         * @return The <a href="https://en.wikipedia.org/wiki/Server_Name_Indication">SNI</a>
+         * hostname which the client used during TLS handshake.
+         */
+        public String sniHostname();
+
+        /**
+         * Connect to the upstream broker at the given {@code host} and {@code port},
+         * using the given protocol filters
+         * @param host The host
+         * @param port The port
+         * @param filters The filters
+         */
+        public void connect(String host, int port, KrpcFilter[] filters);
+
+        // TODO add API for delayed responses
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -404,7 +404,7 @@ public class KafkaProxyFrontendHandler
     }
 
     @Override
-    public String clientAddress() {
+    public String clientHost() {
         if (haProxyMessage != null) {
             return haProxyMessage.sourceAddress();
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -5,13 +5,32 @@
  */
 package io.kroxylicious.proxy.internal;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Arrays;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ApiVersionsResponseDataJsonConverter;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.codec.CorrelationManager;
+import io.kroxylicious.proxy.internal.codec.DecodePredicate;
 import io.kroxylicious.proxy.internal.codec.KafkaRequestEncoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -21,40 +40,126 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SniCompletionEvent;
 
-public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
+public class KafkaProxyFrontendHandler
+        extends ChannelInboundHandlerAdapter
+        implements NetFilter.NetFilterContext {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyFrontendHandler.class);
 
-    private final String remoteHost;
-    private final int remotePort;
-    private final CorrelationManager correlationManager;
+    /** Cache ApiVersions response which we use when returning ApiVersions ourselves */
+    private static final ApiVersionsResponseData API_VERSIONS_RESPONSE;
+    static {
+        var objectMapper = new ObjectMapper();
+        try (var parser = KafkaProxyFrontendHandler.class.getResourceAsStream("/ApiVersions-3.2.json")) {
+            API_VERSIONS_RESPONSE = ApiVersionsResponseDataJsonConverter.read(objectMapper.readTree(parser), (short) 3);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     private final boolean logNetwork;
     private final boolean logFrames;
-    private final KrpcFilter[] filters;
 
     private ChannelHandlerContext outboundCtx;
     private KafkaProxyBackendHandler backendHandler;
     private boolean pendingFlushes;
-    private ChannelHandlerContext blockedInboundCtx;
 
-    public KafkaProxyFrontendHandler(String remoteHost,
-                                     int remotePort,
-                                     CorrelationManager correlationManager,
-                                     KrpcFilter[] filters,
-                                     boolean logNetwork,
-                                     boolean logFrames) {
-        this.remoteHost = remoteHost;
-        this.remotePort = remotePort;
-        this.correlationManager = correlationManager;
+    private final NetFilter filter;
+    private final SaslDecodePredicate dp;
+
+    private AuthenticationEvent authentication;
+
+    private String clientSoftwareName;
+    private String clientSoftwareVersion;
+    private String sniHostname;
+
+    private ChannelHandlerContext inboundCtx;
+    // The message buffered while we connect to the outbound cluster
+    // There can only be one such because auto read is disabled until outbound
+    // channel activation
+    private Object bufferedMsg;
+    // Flag if we receive a channelReadComplete() prior to outbound connection activation
+    // so we can perform the channelReadComplete()/outbound flush & auto_read
+    // once the outbound channel is active
+    private boolean pendingReadComplete = true;
+
+    @VisibleForTesting
+    enum State {
+        /** The initial state */
+        START,
+        /** An HAProxy message has been received */
+        HA_PROXY,
+        /** A Kafka ApiVersions request has been received */
+        API_VERSIONS,
+        /** Some other Kafka request has been received and we're in the process of connecting to the outbound cluster */
+        CONNECTING,
+        /** The outbound connection is connected but not yet active */
+        CONNECTED,
+        /** The outbound connection is active */
+        OUTBOUND_ACTIVE,
+        /** The connection to the outbound cluster failed */
+        FAILED
+    }
+
+    /**
+     * The current state.
+     * Transitions:
+     * <code><pre>
+     * ST_START ──→ ST_HA_PROXY ──→ ST_API_VERSIONS ─╭─→ ST_CONNECTING ──→ ST_CONNECTED
+     *     ╰─────────────╰────────────────╰──────────╯      ╰──→ ST_FAILED
+     * </pre></code>
+     * Unexpected state transitions and exceptions also cause a
+     * transition to {@link State#FAILED} (via {@link #illegalState(String)}}
+     */
+    private State state = State.START;
+
+    private boolean isInboundBlocked = true;
+    private HAProxyMessage haProxyMessage;
+
+    KafkaProxyFrontendHandler(NetFilter filter,
+                              SaslDecodePredicate dp,
+                              boolean logNetwork,
+                              boolean logFrames) {
+        this.filter = filter;
+        this.dp = dp;
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
-        this.filters = filters;
+    }
+
+    private IllegalStateException illegalState(String msg) {
+        String name = state.name();
+        state = State.FAILED;
+        return new IllegalStateException((msg == null ? "" : msg + ", ") + "state=" + name);
+    }
+
+    @VisibleForTesting
+    State state() {
+        return state;
     }
 
     public void outboundChannelActive(ChannelHandlerContext ctx) {
+        if (state != State.CONNECTED) {
+            throw illegalState(null);
+        }
+        LOGGER.trace("{}: outboundChannelActive", inboundCtx.channel().id());
         outboundCtx = ctx;
+        // connection is complete, so first forward the buffered message
+        forwardOutbound(ctx, bufferedMsg);
+        bufferedMsg = null; // don't pin in memory once we no longer need it
+        if (pendingReadComplete) {
+            pendingReadComplete = false;
+            channelReadComplete(ctx);
+        }
+        state = State.OUTBOUND_ACTIVE;
+
+        var inboundChannel = this.inboundCtx.channel();
+        // once buffered message has been forwarded we enable auto-read to start accepting further messages
+        inboundChannel.config().setAutoRead(true);
     }
 
     @Override
@@ -67,28 +172,80 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) {
-        LOGGER.trace("Channel active {}", ctx);
-        final Channel inboundChannel = ctx.channel();
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (state == State.OUTBOUND_ACTIVE) { // post-backend connection
+            forwardOutbound(ctx, msg);
+        }
+        else { // pre-backend connection
+            if (state == State.START
+                    && msg instanceof HAProxyMessage) {
+                this.haProxyMessage = (HAProxyMessage) msg;
+                state = State.HA_PROXY;
+            }
+            else if ((state == State.START
+                    || state == State.HA_PROXY)
+                    && msg instanceof DecodedRequestFrame
+                    && ((DecodedRequestFrame<?>) msg).apiKey() == ApiKeys.API_VERSIONS) {
+                // This handler can respond to ApiVersions itself
+                writeApiVersionsResponse(ctx, (DecodedRequestFrame<ApiVersionsRequestData>) msg);
+                // ctx.fireChannelRead(msg);
+                // Request to read the following request
+                ctx.channel().read();
+                state = State.API_VERSIONS;
+            }
+            else if ((state == State.START
+                    || state == State.HA_PROXY
+                    || state == State.API_VERSIONS)
+                    && msg instanceof RequestFrame) {
+                if (bufferedMsg != null) {
+                    // Single buffered message assertion failed
+                    throw illegalState("Already have buffered msg");
+                }
+                state = State.CONNECTING;
+                // But for any other request we'll need a backend connection
+                // (for which we need to ask the filter which cluster to connect to
+                // and with what filters)
+                this.bufferedMsg = msg;
+                // TODO ensure that the filter makes exactly one upstream connection?
+                // Or not for the topic routing case
+
+                // Note filter.upstreamBroker will call back on the connect() method below
+                filter.upstreamBroker(this);
+            }
+            else {
+                throw illegalState("Unexpected channelRead() message of " + msg.getClass());
+            }
+        }
+    }
+
+    @Override
+    public void connect(String remoteHost, int remotePort, KrpcFilter[] filters) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("{}: Connecting to backend broker {}:{} using filters {}",
+                    inboundCtx.channel().id(), remoteHost, remotePort, Arrays.toString(filters));
+        }
+        var correlationManager = new CorrelationManager();
+
+        final Channel inboundChannel = inboundCtx.channel();
 
         // Start the upstream connection attempt.
         Bootstrap b = new Bootstrap();
-        backendHandler = new KafkaProxyBackendHandler(this, ctx);
+        backendHandler = new KafkaProxyBackendHandler(this, inboundCtx);
         b.group(inboundChannel.eventLoop())
-                .channel(ctx.channel().getClass())
+                .channel(inboundChannel.getClass())
                 .handler(backendHandler)
                 .option(ChannelOption.AUTO_READ, true)
                 .option(ChannelOption.TCP_NODELAY, true);
 
         LOGGER.trace("Connecting to outbound {}:{}", remoteHost, remotePort);
-        ChannelFuture connectFuture = b.connect(remoteHost, remotePort);
+        ChannelFuture connectFuture = getConnect(remoteHost, remotePort, b);
         Channel outboundChannel = connectFuture.channel();
         ChannelPipeline pipeline = outboundChannel.pipeline();
 
         if (logFrames) {
             pipeline.addFirst("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamFrameLogger"));
         }
-        addFiltersToPipeline(pipeline);
+        addFiltersToPipeline(filters, pipeline);
         pipeline.addFirst("responseDecoder", new KafkaResponseDecoder(correlationManager));
         pipeline.addFirst("requestEncoder", new KafkaRequestEncoder(correlationManager));
         if (logNetwork) {
@@ -97,11 +254,14 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
 
         connectFuture.addListener(future -> {
             if (future.isSuccess()) {
-                LOGGER.trace("Outbound connect complete ({}), register interest to read on inbound channel {}", outboundChannel.localAddress(), inboundChannel);
-                // connection complete start to read first data
-                inboundChannel.config().setAutoRead(true);
+                state = State.CONNECTED;
+                LOGGER.trace("{}: Outbound connected", inboundCtx.channel().id());
+                // Now we know which filters are to be used we need to update the DecodePredicate
+                // so that the decoder starts decoding the messages that the filters want to intercept
+                dp.setDelegate(DecodePredicate.forFilters(filters));
             }
             else {
+                state = State.FAILED;
                 // Close the connection if the connection attempt has failed.
                 LOGGER.trace("Outbound connect error, closing inbound channel", future.cause());
                 inboundChannel.close();
@@ -109,22 +269,27 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
         });
     }
 
-    private void addFiltersToPipeline(ChannelPipeline pipeline) {
+    @VisibleForTesting
+    ChannelFuture getConnect(String remoteHost, int remotePort, Bootstrap b) {
+        return b.connect(remoteHost, remotePort);
+    }
+
+    private void addFiltersToPipeline(KrpcFilter[] filters, ChannelPipeline pipeline) {
         for (var filter : filters) {
             pipeline.addFirst(filter.toString(), new FilterHandler(filter, 20000));
         }
     }
 
-    @Override
-    public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-        LOGGER.trace("Completed read on inbound channel: {}", msg);
+    public void forwardOutbound(final ChannelHandlerContext ctx, Object msg) {
         if (outboundCtx == null) {
-            LOGGER.trace("Outbound is not active");
+            LOGGER.trace("READ on inbound {} ignored because outbound is not active (msg: {})",
+                    ctx.channel(), msg);
             return;
         }
         final Channel outboundChannel = outboundCtx.channel();
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Outbound writable: {}", outboundChannel.isWritable());
+            LOGGER.trace("READ on inbound {} outbound {} (outbound.isWritable: {}, msg: {})",
+                    ctx.channel(), outboundChannel, outboundChannel.isWritable(), msg);
             LOGGER.trace("Outbound bytesBeforeUnwritable: {}", outboundChannel.bytesBeforeUnwritable());
             LOGGER.trace("Outbound config: {}", outboundChannel.config());
             LOGGER.trace("Outbound is active, writing and flushing {}", msg);
@@ -137,37 +302,65 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
             outboundChannel.writeAndFlush(msg, outboundCtx.voidPromise());
             pendingFlushes = false;
         }
+        LOGGER.trace("/READ");
+    }
+
+    /**
+     * Sends an ApiVersions response from this handler to the client
+     * (i.e. prior to having backend connection)
+     */
+    private void writeApiVersionsResponse(ChannelHandlerContext ctx, DecodedRequestFrame<ApiVersionsRequestData> frame) {
+        // TODO check the format of the strings using a regex
+        this.clientSoftwareName = frame.body().clientSoftwareName();
+        this.clientSoftwareVersion = frame.body().clientSoftwareVersion();
+
+        short apiVersion = frame.apiVersion();
+        int correlationId = frame.correlationId();
+        ResponseHeaderData header = new ResponseHeaderData()
+                .setCorrelationId(correlationId);
+        LOGGER.debug("{}: Writing ApiVersions response", ctx.channel());
+        ctx.writeAndFlush(new DecodedResponseFrame<>(
+                apiVersion, correlationId, header, API_VERSIONS_RESPONSE));
     }
 
     public void outboundWritabilityChanged(ChannelHandlerContext outboundCtx) {
-        assert this.outboundCtx == outboundCtx;
-        final ChannelHandlerContext inboundCtx = blockedInboundCtx;
-        if (inboundCtx != null && outboundCtx.channel().isWritable()) {
-            blockedInboundCtx = null;
+        if (this.outboundCtx != outboundCtx) {
+            throw illegalState("Mismatching outboundCtx");
+        }
+        if (isInboundBlocked && outboundCtx.channel().isWritable()) {
+            isInboundBlocked = false;
             inboundCtx.channel().config().setAutoRead(true);
         }
     }
 
     @Override
-    public void channelReadComplete(final ChannelHandlerContext ctx) throws Exception {
+    public void channelReadComplete(final ChannelHandlerContext ctx) {
         if (outboundCtx == null) {
-            LOGGER.trace("Outbound is not active");
+            LOGGER.trace("READ_COMPLETE on inbound {}, ignored because outbound is not active",
+                    ctx.channel());
+            pendingReadComplete = true;
             return;
         }
         final Channel outboundChannel = outboundCtx.channel();
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("READ_COMPLETE on inbound {} outbound {} (pendingFlushes: {}, isInboundBlocked: {}, output.isWritable: {})",
+                    ctx.channel(), outboundChannel,
+                    pendingFlushes, isInboundBlocked, outboundChannel.isWritable());
+        }
         if (pendingFlushes) {
             pendingFlushes = false;
             outboundChannel.flush();
         }
         if (!outboundChannel.isWritable()) {
             ctx.channel().config().setAutoRead(false);
-            this.blockedInboundCtx = ctx;
+            isInboundBlocked = true;
         }
 
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
+        LOGGER.trace("INACTIVE on inbound {}", ctx.channel());
         if (outboundCtx == null) {
             return;
         }
@@ -192,4 +385,90 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
         }
     }
 
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object event) throws Exception {
+        if (event instanceof SniCompletionEvent) {
+            SniCompletionEvent sniCompletionEvent = (SniCompletionEvent) event;
+            if (sniCompletionEvent.isSuccess()) {
+                this.sniHostname = sniCompletionEvent.hostname();
+            }
+            // TODO handle the failure case
+        }
+        else if (event instanceof AuthenticationEvent) {
+            this.authentication = (AuthenticationEvent) event;
+        }
+        super.userEventTriggered(ctx, event);
+    }
+
+    @Override
+    public String clientAddress() {
+        if (haProxyMessage != null) {
+            return haProxyMessage.sourceAddress();
+        }
+        else {
+            SocketAddress socketAddress = inboundCtx.channel().remoteAddress();
+            if (socketAddress instanceof InetSocketAddress) {
+                return ((InetSocketAddress) socketAddress).getAddress().getHostAddress();
+            }
+            else {
+                return String.valueOf(socketAddress);
+            }
+        }
+    }
+
+    @Override
+    public int clientPort() {
+        if (haProxyMessage != null) {
+            return haProxyMessage.sourcePort();
+        }
+        else {
+            SocketAddress socketAddress = inboundCtx.channel().remoteAddress();
+            if (socketAddress instanceof InetSocketAddress) {
+                return ((InetSocketAddress) socketAddress).getPort();
+            }
+            else {
+                return -1;
+            }
+        }
+    }
+
+    @Override
+    public SocketAddress srcAddress() {
+        return inboundCtx.channel().remoteAddress();
+    }
+
+    @Override
+    public String authorizedId() {
+        return authentication != null ? authentication.authorizationId() : null;
+    }
+
+    @Override
+    public String clientSoftwareName() {
+        return clientSoftwareName;
+    }
+
+    @Override
+    public String clientSoftwareVersion() {
+        return clientSoftwareVersion;
+    }
+
+    @Override
+    public String sniHostname() {
+        return sniHostname;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        this.inboundCtx = ctx;
+        LOGGER.trace("{}: channelActive", inboundCtx.channel().id());
+        // Initially the channel is not auto reading, so read the first batch of requests
+        ctx.channel().config().setAutoRead(false);
+        ctx.channel().read();
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaProxyFrontendHandler{inbound = " + inboundCtx.channel() + ", state = " + state + "}";
+    }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -221,6 +221,9 @@ public class KafkaProxyFrontendHandler
 
     @Override
     public void initiateConnect(String remoteHost, int remotePort, KrpcFilter[] filters) {
+        if (backendHandler != null) {
+            throw new IllegalStateException();
+        }
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: Connecting to backend broker {}:{} using filters {}",
                     inboundCtx.channel().id(), remoteHost, remotePort, Arrays.toString(filters));

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -210,7 +210,7 @@ public class KafkaProxyFrontendHandler
                 // Or not for the topic routing case
 
                 // Note filter.upstreamBroker will call back on the connect() method below
-                filter.upstreamBroker(this);
+                filter.selectServer(this);
             }
             else {
                 throw illegalState("Unexpected channelRead() message of " + msg.getClass());
@@ -219,7 +219,7 @@ public class KafkaProxyFrontendHandler
     }
 
     @Override
-    public void connect(String remoteHost, int remotePort, KrpcFilter[] filters) {
+    public void initiateConnect(String remoteHost, int remotePort, KrpcFilter[] filters) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: Connecting to backend broker {}:{} using filters {}",
                     inboundCtx.channel().id(), remoteHost, remotePort, Arrays.toString(filters));

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -110,8 +110,10 @@ public class KafkaProxyFrontendHandler
      * The current state.
      * Transitions:
      * <code><pre>
-     * ST_START ──→ ST_HA_PROXY ──→ ST_API_VERSIONS ─╭─→ ST_CONNECTING ──→ ST_CONNECTED
-     *     ╰─────────────╰────────────────╰──────────╯      ╰──→ ST_FAILED
+     *    START ──→ HA_PROXY ──→ API_VERSIONS ─╭─→ CONNECTING ──→ CONNECTED ──→ OUTBOUND_ACTIVE
+     *      ╰──────────╰──────────────╰────────╯        |
+     *                                                  |
+     *                                                  ╰──→ FAILED
      * </pre></code>
      * Unexpected state transitions and exceptions also cause a
      * transition to {@link State#FAILED} (via {@link #illegalState(String)}}
@@ -188,7 +190,6 @@ public class KafkaProxyFrontendHandler
                     && ((DecodedRequestFrame<?>) msg).apiKey() == ApiKeys.API_VERSIONS) {
                 // This handler can respond to ApiVersions itself
                 writeApiVersionsResponse(ctx, (DecodedRequestFrame<ApiVersionsRequestData>) msg);
-                // ctx.fireChannelRead(msg);
                 // Request to read the following request
                 ctx.channel().read();
                 state = State.API_VERSIONS;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -5,16 +5,19 @@
  */
 package io.kroxylicious.proxy.internal;
 
+import java.util.Map;
+
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
-import io.kroxylicious.proxy.internal.codec.CorrelationManager;
+import io.kroxylicious.proxy.filter.NetFilter;
 import io.kroxylicious.proxy.internal.codec.KafkaRequestDecoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseEncoder;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 
@@ -22,20 +25,20 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyInitializer.class);
 
-    private final String remoteHost;
-    private final int remotePort;
-    private final FilterChainFactory filterChainFactory;
     private final boolean logNetwork;
     private final boolean logFrames;
+    private final boolean haproxyProtocol;
+    private final Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> authnHandlers;
+    private final NetFilter netFilter;
 
-    public KafkaProxyInitializer(String remoteHost,
-                                 int remotePort,
-                                 FilterChainFactory filterChainFactory,
+    public KafkaProxyInitializer(boolean haproxyProtocol,
+                                 Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> authnMechanismHandlers,
+                                 NetFilter netFilter,
                                  boolean logNetwork,
                                  boolean logFrames) {
-        this.remoteHost = remoteHost;
-        this.remotePort = remotePort;
-        this.filterChainFactory = filterChainFactory;
+        this.haproxyProtocol = haproxyProtocol;
+        this.authnHandlers = authnMechanismHandlers;
+        this.netFilter = netFilter;
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
     }
@@ -46,29 +49,35 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
 
         LOGGER.trace("Connection from {} to my address {}", ch.remoteAddress(), ch.localAddress());
 
-        var correlation = new CorrelationManager();
-
         ChannelPipeline pipeline = ch.pipeline();
         if (logNetwork) {
             pipeline.addLast("networkLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamNetworkLogger", LogLevel.INFO));
         }
-        var filters = filterChainFactory.createFilters();
+
+        // Add handler here
+        if (haproxyProtocol) {
+            LOGGER.debug("Adding haproxy handler");
+            pipeline.addLast("HAProxyMessageDecoder", new HAProxyMessageDecoder());
+        }
+
+        var dp = new SaslDecodePredicate(authnHandlers != null && !authnHandlers.isEmpty());
         // The decoder, this only cares about the filters
         // because it needs to know whether to decode requests
-        KafkaRequestDecoder decoder = new KafkaRequestDecoder(filters);
+        KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp);
         pipeline.addLast("requestDecoder", decoder);
 
         pipeline.addLast("responseEncoder", new KafkaResponseEncoder());
         if (logFrames) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));
         }
-        
-        pipeline.addLast("frontendHandler", new KafkaProxyFrontendHandler(remoteHost,
-                remotePort,
-                correlation,
-                filters,
-                logNetwork,
-                logFrames));
+
+        if (!authnHandlers.isEmpty()) {
+            LOGGER.debug("Adding authn handler for handlers {}", authnHandlers);
+            pipeline.addLast(new KafkaAuthnHandler(ch, authnHandlers));
+        }
+
+        pipeline.addLast("netHandler", new KafkaProxyFrontendHandler(netFilter, dp, logNetwork, logFrames));
+        LOGGER.debug("{}: Initial pipeline: {}", ch, pipeline);
     }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -37,7 +37,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
                                  boolean logNetwork,
                                  boolean logFrames) {
         this.haproxyProtocol = haproxyProtocol;
-        this.authnHandlers = authnMechanismHandlers;
+        this.authnHandlers = authnMechanismHandlers != null ? authnMechanismHandlers : Map.of();
         this.netFilter = netFilter;
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
@@ -60,7 +60,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
             pipeline.addLast("HAProxyMessageDecoder", new HAProxyMessageDecoder());
         }
 
-        var dp = new SaslDecodePredicate(authnHandlers != null && !authnHandlers.isEmpty());
+        var dp = new SaslDecodePredicate(!authnHandlers.isEmpty());
         // The decoder, this only cares about the filters
         // because it needs to know whether to decode requests
         KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.proxy.internal.codec.DecodePredicate;
+
+class SaslDecodePredicate implements DecodePredicate {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaslDecodePredicate.class);
+
+    private final boolean handleSasl;
+    private DecodePredicate delegate = null;
+
+    public SaslDecodePredicate(boolean handleSasl) {
+        this.handleSasl = handleSasl;
+    }
+
+    public void setDelegate(DecodePredicate delegate) {
+        LOGGER.debug("Setting delegate {}", delegate);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
+        boolean result;
+        if (apiKey == ApiKeys.API_VERSIONS) {
+            // TODO For now let's assume we need to always decode this, since the NetHandler
+            // currently does this. At some point we'll need a way to figure out the mutual intersection
+            // of api versions over all backend clusters plus the proxy itself.
+            result = true;
+        }
+        else if (apiKey == ApiKeys.SASL_HANDSHAKE
+                || apiKey == ApiKeys.SASL_AUTHENTICATE) {
+            result = handleSasl;
+        }
+        else {
+            result = delegate == null ? true : delegate.shouldDecodeRequest(apiKey, apiVersion);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
+        return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "SaslDecodePredicate(" +
+                "handleSasl=" + handleSasl +
+                ", delegate=" + delegate +
+                ')';
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
@@ -55,14 +55,14 @@ class SaslDecodePredicate implements DecodePredicate {
             result = handleSasl;
         }
         else {
-            result = delegate == null ? true : delegate.shouldDecodeRequest(apiKey, apiVersion);
+            result = delegate == null || delegate.shouldDecodeRequest(apiKey, apiVersion);
         }
         return result;
     }
 
     @Override
     public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
-        return delegate == null ? true : delegate.shouldDecodeResponse(apiKey, apiVersion);
+        return delegate == null || delegate.shouldDecodeResponse(apiKey, apiVersion);
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/DecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/DecodePredicate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.codec;
+
+import java.util.Arrays;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+/**
+ * Encapsulates decisions about whether requests and responses should be
+ * fully deserialized into POJOs, or passed through as byte buffers with
+ * minimal deserialization.
+ *
+ * The actual decision can depend on which filters are in use, which can depend on
+ * who the authorized user or, or which back-end cluster they're connected to.
+ */
+public interface DecodePredicate {
+    public static DecodePredicate forFilters(KrpcFilter... filters) {
+        return new DecodePredicate() {
+            @Override
+            public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
+                for (var filter : filters) {
+                    if (filter.shouldDeserializeResponse(apiKey, apiVersion)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
+                for (var filter : filters) {
+                    if (filter.shouldDeserializeRequest(apiKey, apiVersion)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return "DecodePredicate$forFilters{" + Arrays.toString(filters) + "}";
+            }
+        };
+    }
+
+    public boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion);
+
+    public boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion);
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
@@ -25,7 +25,7 @@ public abstract class KafkaMessageDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    protected synchronized void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+    public synchronized void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         while (in.readableBytes() > 4) {
             try {
                 int sof = in.readerIndex();

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
@@ -25,7 +25,7 @@ public abstract class KafkaMessageDecoder extends ByteToMessageDecoder {
     }
 
     @Override
-    public synchronized void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+    public void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         while (in.readableBytes() > 4) {
             try {
                 int sof = in.readerIndex();

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
 import org.apache.kafka.common.message.SaslHandshakeRequestData;
 import org.apache.kafka.common.message.StopReplicaRequestData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
@@ -41,7 +42,6 @@ import org.apache.kafka.common.protocol.Readable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
@@ -53,11 +53,11 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaRequestDecoder.class);
 
-    private final KrpcFilter[] filters;
+    private final DecodePredicate decodePredicate;
 
-    public KafkaRequestDecoder(KrpcFilter... filters) {
+    public KafkaRequestDecoder(DecodePredicate decodePredicate) {
         super();
-        this.filters = filters;
+        this.decodePredicate = decodePredicate;
     }
 
     @Override
@@ -84,10 +84,11 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
 
         RequestHeaderData header = null;
         final ByteBufAccessorImpl accessor;
-        var decodeRequest = shouldDecodeRequest(apiKey, apiVersion);
-        boolean decodeResponse = shouldDecodeResponse(apiKey, apiVersion);
+        var decodeRequest = decodePredicate.shouldDecodeRequest(apiKey, apiVersion);
+        LOGGER.debug("Decode {}/v{} request? {}, Predicate {} ", apiKey, apiVersion, decodeRequest, decodePredicate);
+        boolean decodeResponse = decodePredicate.shouldDecodeResponse(apiKey, apiVersion);
+        LOGGER.debug("Decode {}/v{} response? {}, Predicate {}", apiKey, apiVersion, decodeResponse, decodePredicate);
         short headerVersion = apiKey.requestHeaderVersion(apiVersion);
-        log().trace("{}: decodeRequest {}, decodeResponse {}", ctx, decodeRequest, decodeResponse);
         if (decodeRequest) {
             if (log().isTraceEnabled()) { // avoid boxing
                 log().trace("{}: headerVersion {}", ctx, headerVersion);
@@ -125,24 +126,6 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
         }
 
         return frame;
-    }
-
-    private boolean shouldDecodeResponse(ApiKeys apiKey, short apiVersion) {
-        for (var filter : filters) {
-            if (filter.shouldDeserializeResponse(apiKey, apiVersion)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean shouldDecodeRequest(ApiKeys apiKey, short apiVersion) {
-        for (var filter : filters) {
-            if (filter.shouldDeserializeRequest(apiKey, apiVersion)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private OpaqueRequestFrame opaqueFrame(ByteBuf in,
@@ -220,6 +203,8 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
                 return new WriteTxnMarkersRequestData(accessor, apiVersion);
             case TXN_OFFSET_COMMIT:
                 return new TxnOffsetCommitRequestData(accessor, apiVersion);
+            case SASL_AUTHENTICATE:
+                return new SaslAuthenticateRequestData(accessor, apiVersion);
             default:
                 throw new IllegalArgumentException("Unsupported API key " + apiKey);
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
@@ -58,7 +58,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
         out.writeInt(upstreamCorrelationId);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: {} downstream correlation id {} assigned upstream correlation id: {}",
-                    ctx.channel(), ApiKeys.forId(apiKey), downstreamCorrelationId, upstreamCorrelationId);
+                    ctx, ApiKeys.forId(apiKey), downstreamCorrelationId, upstreamCorrelationId);
         }
         out.readerIndex(ri);
         out.writerIndex(wi);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
 import org.apache.kafka.common.message.StopReplicaRequestData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
@@ -78,7 +79,7 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             throw new AssertionError("Missing correlation id " + upstreamCorrelationId);
         }
         else if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("{}: Recovered correlation {} for upstream correlation id {}", ctx.channel(), correlation, upstreamCorrelationId);
+            LOGGER.debug("{}: Recovered correlation {} for upstream correlation id {}", ctx, correlation, upstreamCorrelationId);
         }
         int correlationId = correlation.downstreamCorrelationId();
         in.writerIndex(ri);
@@ -179,6 +180,8 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
                 return new WriteTxnMarkersResponseData(accessor, apiVersion);
             case TXN_OFFSET_COMMIT: // ???
                 return new TxnOffsetCommitResponseData(accessor, apiVersion);
+            case SASL_AUTHENTICATE:
+                return new SaslAuthenticateRequestData(accessor, apiVersion);
             default:
                 throw new IllegalArgumentException("Unsupported API key " + apiKey);
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseEncoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseEncoder.java
@@ -18,4 +18,5 @@ public class KafkaResponseEncoder extends KafkaMessageEncoder<ResponseFrame> {
     protected Logger log() {
         return LOGGER;
     }
+
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FixedNetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FixedNetFilter.java
@@ -12,13 +12,13 @@ import io.kroxylicious.proxy.filter.NetFilter;
  * Implementation of {@link NetFilter} that is able to connect to a
  * single cluster, using a single, constant {@link FilterChainFactory}.
  */
-public class SimpleNetFilter implements NetFilter {
+public class FixedNetFilter implements NetFilter {
 
     private final String remoteHost;
     private final int remotePort;
     private final FilterChainFactory filterChainFactory;
 
-    public SimpleNetFilter(String remoteHost, int remotePort, FilterChainFactory filterChainFactory) {
+    public FixedNetFilter(String remoteHost, int remotePort, FilterChainFactory filterChainFactory) {
         this.remoteHost = remoteHost;
         this.remotePort = remotePort;
         this.filterChainFactory = filterChainFactory;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/SimpleNetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/SimpleNetFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.filter;
+
+import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
+import io.kroxylicious.proxy.filter.NetFilter;
+
+/**
+ * Implementation of {@link NetFilter} that is able to connect to a
+ * single cluster, using a single, constant {@link FilterChainFactory}.
+ */
+public class SimpleNetFilter implements NetFilter {
+
+    private final String remoteHost;
+    private final int remotePort;
+    private final FilterChainFactory filterChainFactory;
+
+    public SimpleNetFilter(String remoteHost, int remotePort, FilterChainFactory filterChainFactory) {
+        this.remoteHost = remoteHost;
+        this.remotePort = remotePort;
+        this.filterChainFactory = filterChainFactory;
+    }
+
+    @Override
+    public void upstreamBroker(NetFilterContext context) {
+        context.connect(remoteHost, remotePort, filterChainFactory.createFilters());
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/SimpleNetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/SimpleNetFilter.java
@@ -25,7 +25,7 @@ public class SimpleNetFilter implements NetFilter {
     }
 
     @Override
-    public void upstreamBroker(NetFilterContext context) {
-        context.connect(remoteHost, remotePort, filterChainFactory.createFilters());
+    public void selectServer(NetFilterContext context) {
+        context.initiateConnect(remoteHost, remotePort, filterChainFactory.createFilters());
     }
 }

--- a/kroxylicious/src/main/resources/ApiVersions-3.2.json
+++ b/kroxylicious/src/main/resources/ApiVersions-3.2.json
@@ -1,0 +1,242 @@
+{
+  "errorCode" : 0,
+  "apiKeys" : [ {
+    "apiKey" : 0,
+    "minVersion" : 0,
+    "maxVersion" : 9
+  }, {
+    "apiKey" : 1,
+    "minVersion" : 0,
+    "maxVersion" : 13
+  }, {
+    "apiKey" : 2,
+    "minVersion" : 0,
+    "maxVersion" : 7
+  }, {
+    "apiKey" : 3,
+    "minVersion" : 0,
+    "maxVersion" : 12
+  }, {
+    "apiKey" : 4,
+    "minVersion" : 0,
+    "maxVersion" : 6
+  }, {
+    "apiKey" : 5,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 6,
+    "minVersion" : 0,
+    "maxVersion" : 7
+  }, {
+    "apiKey" : 7,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 8,
+    "minVersion" : 0,
+    "maxVersion" : 8
+  }, {
+    "apiKey" : 9,
+    "minVersion" : 0,
+    "maxVersion" : 8
+  }, {
+    "apiKey" : 10,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 11,
+    "minVersion" : 0,
+    "maxVersion" : 9
+  }, {
+    "apiKey" : 12,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 13,
+    "minVersion" : 0,
+    "maxVersion" : 5
+  }, {
+    "apiKey" : 14,
+    "minVersion" : 0,
+    "maxVersion" : 5
+  }, {
+    "apiKey" : 15,
+    "minVersion" : 0,
+    "maxVersion" : 5
+  }, {
+    "apiKey" : 16,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 17,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 18,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 19,
+    "minVersion" : 0,
+    "maxVersion" : 7
+  }, {
+    "apiKey" : 20,
+    "minVersion" : 0,
+    "maxVersion" : 6
+  }, {
+    "apiKey" : 21,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 22,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 23,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 24,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 25,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 26,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 27,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 28,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 29,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 30,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 31,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 32,
+    "minVersion" : 0,
+    "maxVersion" : 4
+  }, {
+    "apiKey" : 33,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 34,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 35,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 36,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 37,
+    "minVersion" : 0,
+    "maxVersion" : 3
+  }, {
+    "apiKey" : 38,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 39,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 40,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 41,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 42,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 43,
+    "minVersion" : 0,
+    "maxVersion" : 2
+  }, {
+    "apiKey" : 44,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 45,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 46,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 47,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 48,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 49,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 50,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 51,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 56,
+    "minVersion" : 0,
+    "maxVersion" : 1
+  }, {
+    "apiKey" : 57,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 60,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 61,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 65,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 66,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  }, {
+    "apiKey" : 67,
+    "minVersion" : 0,
+    "maxVersion" : 0
+  } ],
+  "throttleTimeMs" : 0,
+  "finalizedFeaturesEpoch" : 0
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class FilterHandlerTest extends FilterHarness {
+public class FilterHandlerTest extends FilterHarness {
 
     @Test
     public void testForwardRequest() {

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -100,13 +100,11 @@ public class KafkaAuthnHandlerTest {
         // saslAuthenticateVersion == null => use a base SASL request (no kafka header)
         private final Short saslAuthenticateVersion;
 
-
         public RequestVersions(Short apiVersionsVersion, Short saslHandshakeVersion, Short saslAuthenticateVersion) {
             this.apiVersionsVersion = apiVersionsVersion;
             this.saslHandshakeVersion = saslHandshakeVersion;
             this.saslAuthenticateVersion = saslAuthenticateVersion;
         }
-
 
         boolean useBare() {
             return saslAuthenticateVersion == null;

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -100,11 +100,13 @@ public class KafkaAuthnHandlerTest {
         // saslAuthenticateVersion == null => use a base SASL request (no kafka header)
         private final Short saslAuthenticateVersion;
 
+
         public RequestVersions(Short apiVersionsVersion, Short saslHandshakeVersion, Short saslAuthenticateVersion) {
             this.apiVersionsVersion = apiVersionsVersion;
             this.saslHandshakeVersion = saslHandshakeVersion;
             this.saslAuthenticateVersion = saslAuthenticateVersion;
         }
+
 
         boolean useBare() {
             return saslAuthenticateVersion == null;
@@ -154,7 +156,6 @@ public class KafkaAuthnHandlerTest {
         for (Short apiVersionsVersion : rangeClosed(ApiVersionsRequestData.LOWEST_SUPPORTED_VERSION, ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION)) {
             for (Short handshakeVersion : rangeClosed(SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION, SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)) {
                 for (Short authenticateVersion : rangeClosed(SaslHandshakeRequestData.LOWEST_SUPPORTED_VERSION, SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION)) {
-
                     result.add(new Object[]{ new RequestVersions(apiVersionsVersion, handshakeVersion, authenticateVersion) });
                 }
             }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -225,11 +225,12 @@ class KafkaProxyFrontendHandlerTest {
         assertFalse(inboundChannel.config().isAutoRead(),
                 "Expect inbound autoRead=true, since outbound not yet active");
 
-        // Simular the backend handler receiving channel active and telling the frontent handler
+        // Simulate the backend handler receiving channel active and telling the frontent handler
         ChannelHandlerContext outboundContext = outboundChannel.pipeline().context(outboundChannel.pipeline().names().get(0));
         handler.outboundChannelActive(outboundContext);
         outboundChannel.pipeline().fireChannelActive();
         assertTrue(inboundChannel.config().isAutoRead(),
                 "Expect inbound autoRead=true, since outbound now active");
+        assertEquals(State.OUTBOUND_ACTIVE, handler.state());
     }
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -139,9 +139,9 @@ class KafkaProxyFrontendHandlerTest {
                 assertNull(ctx.authorizedId());
             }
 
-            ctx.connect(CLUSTER_HOST, CLUSTER_PORT, new KrpcFilter[0]);
+            ctx.initiateConnect(CLUSTER_HOST, CLUSTER_PORT, new KrpcFilter[0]);
             return null;
-        }).when(filter).upstreamBroker(valueCapture.capture());
+        }).when(filter).selectServer(valueCapture.capture());
 
         var handler = new KafkaProxyFrontendHandler(filter, dp, false, false) {
             @Override
@@ -176,7 +176,7 @@ class KafkaProxyFrontendHandlerTest {
             writeRequest(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION, new ApiVersionsRequestData()
                     .setClientSoftwareName("foo").setClientSoftwareVersion("1.0.0"));
             assertEquals(State.API_VERSIONS, handler.state());
-            verify(filter, never()).upstreamBroker(handler);
+            verify(filter, never()).selectServer(handler);
         }
 
         if (sendSasl) {
@@ -188,7 +188,7 @@ class KafkaProxyFrontendHandlerTest {
                 // If the pipeline is configured for SASL offload (KafkaAuthnHandler)
                 // then we assume it DOESN'T propagate the SASL frames down the pipeline
                 // and therefore no backend connection happens
-                verify(filter, never()).upstreamBroker(handler);
+                verify(filter, never()).selectServer(handler);
             }
             else {
                 // Simulate the client doing SaslHandshake and SaslAuthentication,
@@ -209,7 +209,7 @@ class KafkaProxyFrontendHandlerTest {
     }
 
     private void handleConnect(NetFilter filter, KafkaProxyFrontendHandler handler) {
-        verify(filter).upstreamBroker(handler);
+        verify(filter).selectServer(handler);
         assertEquals(State.CONNECTED, handler.state());
         assertFalse(inboundChannel.config().isAutoRead(),
                 "Expect inbound autoRead=true, since outbound not yet active");

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -124,11 +124,11 @@ class KafkaProxyFrontendHandlerTest {
             assertEquals(sslConfigured ? SNI_HOSTNAME : null, ctx.sniHostname());
             if (haProxyConfigured) {
                 assertEquals("embedded", String.valueOf(ctx.srcAddress()));
-                assertEquals("1.2.3.4", ctx.clientAddress());
+                assertEquals("1.2.3.4", ctx.clientHost());
             }
             else {
                 assertEquals("embedded", String.valueOf(ctx.srcAddress()));
-                assertEquals("embedded", ctx.clientAddress());
+                assertEquals("embedded", ctx.clientHost());
             }
             assertEquals(sendApiVersions ? "foo" : null, ctx.clientSoftwareName());
             assertEquals(sendApiVersions ? "1.0.0" : null, ctx.clientSoftwareVersion());

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -121,7 +121,12 @@ class KafkaProxyFrontendHandlerTest {
         var filter = mock(NetFilter.class);
         doAnswer(i -> {
             NetFilter.NetFilterContext ctx = i.getArgument(0);
-            assertEquals(sslConfigured ? SNI_HOSTNAME : null, ctx.sniHostname());
+            if (sslConfigured) {
+                assertEquals(SNI_HOSTNAME, ctx.sniHostname());
+            }
+            else {
+                assertNull(ctx.sniHostname());
+            }
             if (haProxyConfigured) {
                 assertEquals("embedded", String.valueOf(ctx.srcAddress()));
                 assertEquals("1.2.3.4", ctx.clientHost());
@@ -130,8 +135,14 @@ class KafkaProxyFrontendHandlerTest {
                 assertEquals("embedded", String.valueOf(ctx.srcAddress()));
                 assertEquals("embedded", ctx.clientHost());
             }
-            assertEquals(sendApiVersions ? "foo" : null, ctx.clientSoftwareName());
-            assertEquals(sendApiVersions ? "1.0.0" : null, ctx.clientSoftwareVersion());
+            if (sendApiVersions) {
+                assertEquals("foo", ctx.clientSoftwareName());
+                assertEquals("1.0.0", ctx.clientSoftwareVersion());
+            }
+            else {
+                assertNull(ctx.clientSoftwareName());
+                assertNull(ctx.clientSoftwareVersion());
+            }
             if (saslOffloadConfigured && sendSasl) {
                 assertEquals("alice", ctx.authorizedId());
             }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.internal.KafkaProxyFrontendHandler.State;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.haproxy.HAProxyCommand;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
+import io.netty.handler.ssl.SniCompletionEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class KafkaProxyFrontendHandlerTest {
+
+    public static final String SNI_HOSTNAME = "external.example.com";
+    public static final String CLUSTER_HOST = "internal.example.org";
+    public static final int CLUSTER_PORT = 9092;
+    EmbeddedChannel inboundChannel;
+    EmbeddedChannel outboundChannel;
+
+    int corrId = 0;
+
+    private void writeRequest(short apiVersion, ApiMessage body) {
+        var apiKey = ApiKeys.forId(body.apiKey());
+
+        int downstreamCorrelationId = corrId++;
+
+        short headerVersion = apiKey.requestHeaderVersion(apiVersion);
+        RequestHeaderData header = new RequestHeaderData()
+                .setRequestApiKey(apiKey.id)
+                .setRequestApiVersion(apiVersion)
+                .setClientId("client-id")
+                .setCorrelationId(downstreamCorrelationId);
+
+        inboundChannel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
+    }
+
+    @BeforeEach
+    public void buildChannel() {
+        inboundChannel = new EmbeddedChannel();
+        corrId = 0;
+    }
+
+    @AfterEach
+    public void closeChannel() {
+        inboundChannel.close();
+    }
+
+    public static List<Arguments> provideArgsForExpectedFlow() {
+        var result = new ArrayList<Arguments>();
+        boolean[] tf = { true, false };
+        for (boolean sslConfigured : tf) {
+            for (boolean haProxyConfigured : tf) {
+                for (boolean saslOffloadConfigured : tf) {
+                    for (boolean sendApiVersions : tf) {
+                        for (boolean sendSasl : tf) {
+                            result.add(Arguments.of(sslConfigured, haProxyConfigured, saslOffloadConfigured, sendApiVersions, sendSasl));
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Test the normal flow, in a number of configurations.
+     * @param sslConfigured Whether SSL is configured
+     * @param haProxyConfigured
+     * @param saslOffloadConfigured
+     * @param sendApiVersions
+     * @param sendSasl
+     */
+    @ParameterizedTest
+    @MethodSource("provideArgsForExpectedFlow")
+    public void expectedFlow(boolean sslConfigured,
+                             boolean haProxyConfigured,
+                             boolean saslOffloadConfigured,
+                             boolean sendApiVersions,
+                             boolean sendSasl) {
+
+        var dp = new SaslDecodePredicate(saslOffloadConfigured);
+        ArgumentCaptor<NetFilter.NetFilterContext> valueCapture = ArgumentCaptor.forClass(NetFilter.NetFilterContext.class);
+        var filter = mock(NetFilter.class);
+        doAnswer(i -> {
+            NetFilter.NetFilterContext ctx = i.getArgument(0);
+            assertEquals(sslConfigured ? SNI_HOSTNAME : null, ctx.sniHostname());
+            if (haProxyConfigured) {
+                assertEquals("embedded", String.valueOf(ctx.srcAddress()));
+                assertEquals("1.2.3.4", ctx.clientAddress());
+            }
+            else {
+                assertEquals("embedded", String.valueOf(ctx.srcAddress()));
+                assertEquals("embedded", ctx.clientAddress());
+            }
+            assertEquals(sendApiVersions ? "foo" : null, ctx.clientSoftwareName());
+            assertEquals(sendApiVersions ? "1.0.0" : null, ctx.clientSoftwareVersion());
+            if (saslOffloadConfigured && sendSasl) {
+                assertEquals("alice", ctx.authorizedId());
+            }
+            else {
+                assertNull(ctx.authorizedId());
+            }
+
+            ctx.connect(CLUSTER_HOST, CLUSTER_PORT, new KrpcFilter[0]);
+            return null;
+        }).when(filter).upstreamBroker(valueCapture.capture());
+
+        var handler = new KafkaProxyFrontendHandler(filter, dp, false, false) {
+            @Override
+            ChannelFuture getConnect(String remoteHost, int remotePort, Bootstrap b) {
+                // This is ugly... basically the EmbeddedChannel doesn't seem to handle the case
+                // of a handler creating an outgoing connection and ends up
+                // trying to re-register the outbound channel => IllegalStateException
+                // So we override this method to short-circuit that
+                outboundChannel = new EmbeddedChannel();
+                return new DefaultChannelPromise(outboundChannel).setSuccess();
+            }
+        };
+        inboundChannel.pipeline().addLast(handler);
+        inboundChannel.pipeline().fireChannelActive();
+
+        assertEquals(State.START, handler.state());
+
+        if (sslConfigured) {
+            // Simulate the SSL handler
+            inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent(SNI_HOSTNAME));
+        }
+
+        if (haProxyConfigured) {
+            // Simulate the HA proxy handler
+            inboundChannel.writeInbound(new HAProxyMessage(HAProxyProtocolVersion.V1,
+                    HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                    "1.2.3.4", "5.6.7.8", 65535, CLUSTER_PORT));
+        }
+
+        if (sendApiVersions) {
+            // Simulate the client doing ApiVersions
+            writeRequest(ApiVersionsRequestData.HIGHEST_SUPPORTED_VERSION, new ApiVersionsRequestData()
+                    .setClientSoftwareName("foo").setClientSoftwareVersion("1.0.0"));
+            assertEquals(State.API_VERSIONS, handler.state());
+            verify(filter, never()).upstreamBroker(handler);
+        }
+
+        if (sendSasl) {
+            if (saslOffloadConfigured) {
+
+                // Simulate the KafkaAuthnHandler having done SASL offload
+                inboundChannel.pipeline().fireUserEventTriggered(new AuthenticationEvent("alice", Map.of()));
+
+                // If the pipeline is configured for SASL offload (KafkaAuthnHandler)
+                // then we assume it DOESN'T propagate the SASL frames down the pipeline
+                // and therefore no backend connection happens
+                verify(filter, never()).upstreamBroker(handler);
+            }
+            else {
+                // Simulate the client doing SaslHandshake and SaslAuthentication,
+                writeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new SaslHandshakeRequestData());
+
+                // these should cause connection to the backend cluster
+                handleConnect(filter, handler);
+                writeRequest(SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new SaslAuthenticateRequestData());
+            }
+        }
+
+        // Simulate a Metadata request
+        writeRequest(MetadataRequestData.HIGHEST_SUPPORTED_VERSION, new MetadataRequestData());
+        if (sendSasl && saslOffloadConfigured) {
+            handleConnect(filter, handler);
+        }
+
+    }
+
+    private void handleConnect(NetFilter filter, KafkaProxyFrontendHandler handler) {
+        verify(filter).upstreamBroker(handler);
+        assertEquals(State.CONNECTED, handler.state());
+        assertFalse(inboundChannel.config().isAutoRead(),
+                "Expect inbound autoRead=true, since outbound not yet active");
+
+        // Simular the backend handler receiving channel active and telling the frontent handler
+        ChannelHandlerContext outboundContext = outboundChannel.pipeline().context(outboundChannel.pipeline().names().get(0));
+        handler.outboundChannelActive(outboundContext);
+        outboundChannel.pipeline().fireChannelActive();
+        assertTrue(inboundChannel.config().isAutoRead(),
+                "Expect inbound autoRead=true, since outbound now active");
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -145,7 +145,7 @@ class KafkaProxyFrontendHandlerTest {
 
         var handler = new KafkaProxyFrontendHandler(filter, dp, false, false) {
             @Override
-            ChannelFuture getConnect(String remoteHost, int remotePort, Bootstrap b) {
+            ChannelFuture initConnection(String remoteHost, int remotePort, Bootstrap b) {
                 // This is ugly... basically the EmbeddedChannel doesn't seem to handle the case
                 // of a handler creating an outgoing connection and ends up
                 // trying to re-register the outbound channel => IllegalStateException

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -24,7 +24,7 @@ import io.netty.buffer.Unpooled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class RequestDecoderTest extends AbstractCodecTest {
+public class RequestDecoderTest extends AbstractCodecTest {
 
     @ParameterizedTest
     @MethodSource("requestApiVersions")
@@ -37,7 +37,7 @@ class RequestDecoderTest extends AbstractCodecTest {
                         AbstractCodecTest::deserializeRequestHeaderUsingKafkaApis,
                         AbstractCodecTest::deserializeApiVersionsRequestUsingKafkaApis,
                         new KafkaRequestDecoder(
-                                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)),
+                                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request))),
                         DecodedRequestFrame.class,
                         (RequestHeaderData header) -> header),
                 "Unexpected correlation id");
@@ -51,7 +51,7 @@ class RequestDecoderTest extends AbstractCodecTest {
                         ApiKeys.API_VERSIONS::requestHeaderVersion,
                         AbstractCodecTest::exampleRequestHeader,
                         AbstractCodecTest::exampleApiVersionsRequest,
-                        new KafkaRequestDecoder(
+                        new KafkaRequestDecoder(DecodePredicate.forFilters(
                                 new ApiVersionsRequestFilter() {
                                     @Override
                                     public boolean shouldDeserializeRequest(ApiKeys apiKey, short apiVersion) {
@@ -62,7 +62,7 @@ class RequestDecoderTest extends AbstractCodecTest {
                                     public void onApiVersionsRequest(ApiVersionsRequestData request, KrpcFilterContext context) {
                                         context.forwardRequest(request);
                                     }
-                                }),
+                                })),
                         OpaqueRequestFrame.class),
                 "Unexpected correlation id");
     }
@@ -80,7 +80,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)).decode(null, byteBuf, messages);
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)))
+                        .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
         assertEquals(0, byteBuf.readerIndex());
@@ -97,7 +98,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)).decode(null, byteBuf, messages);
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)))
+                        .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
         assertEquals(expectRead, byteBuf.readerIndex());
@@ -138,7 +140,8 @@ class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                (ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)).decode(null, byteBuf, messages);
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (request, context) -> context.forwardRequest(request)))
+                        .decode(null, byteBuf, messages);
 
         assertEquals(List.of(DecodedRequestFrame.class, DecodedRequestFrame.class), messageClasses(messages));
         DecodedRequestFrame frame = (DecodedRequestFrame) messages.get(0);

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,6 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.compiler.testRelease>${java.test.version}</maven.compiler.testRelease>
-        <maven.compiler.testSource>${java.test.version}</maven.compiler.testSource>
-        <maven.compiler.testTarget>${java.test.version}</maven.compiler.testTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -247,12 +245,6 @@
                     <version>3.10.1</version>
                     <configuration>
                         <parameters>true</parameters>
-                        <source>11</source>
-                        <target>11</target>
-<!--                        <release>11</release>-->
-                        <testSource>17</testSource>
-                        <testTarget>17</testTarget>
-<!--                        <testRelease>17</testRelease>-->
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.compiler.testRelease>${java.test.version}</maven.compiler.testRelease>
+        <maven.compiler.testSource>${java.test.version}</maven.compiler.testSource>
+        <maven.compiler.testTarget>${java.test.version}</maven.compiler.testTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -245,6 +247,12 @@
                     <version>3.10.1</version>
                     <configuration>
                         <parameters>true</parameters>
+                        <source>11</source>
+                        <target>11</target>
+<!--                        <release>11</release>-->
+                        <testSource>17</testSource>
+                        <testTarget>17</testTarget>
+<!--                        <testRelease>17</testRelease>-->
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
NetFilter provides a plugin abstraction for how the connection to a
backend Kafka cluster happens.

It can consume information from earlier handler in the Netty pipeline
including:

* Network peer information from the TCP layer
* SNI information from the TLS handshake
* Client information propagated by HAProxy using the PROXY protocol
* SASL authentication information from the KafkaAuthnHandler

Using this a `NetFilter` implementation can decide whether and which
backend cluster the client should be connected to, and with what
protocol filters.

Because clients may send `ApiVersions` requests before any other request
this means we need to be able to send an `ApiVersions` response from the
proxy without knowing which backend cluster the client will ultimately
connect to. For now we're just using a fixed response read from a
classpath resource, however we should really improve this, but example by
figuring out an "inclusive response" from a set of backend clusters at
runtime.

Note that this means we have decoupled client connection and
authentication from cluster connection. Therefore bad clients
without valid credentials have no effect on any cluster.

Also provided is a `SimpleNetFilter` implementation of the `NetFilter`
interface, which support a single cluster and a fixed list
of protocol filters.

Fixes #68
Fixes #67 