### PR TITLE
Add a junit5 extension

### DIFF
--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/ContainerBasedKafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/ContainerBasedKafkaCluster.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.kroxylicious.proxy.testkafkacluster;
+package io.kroxylicious.test.kafkacluster;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -39,8 +39,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig.KafkaEndpoints;
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig.KafkaEndpoints.Endpoint;
 import lombok.SneakyThrows;
 
 /**
@@ -100,7 +98,7 @@ public class ContainerBasedKafkaCluster implements Startable, KafkaCluster {
                     .withNetworkAliases("zookeeper");
         }
 
-        Supplier<KafkaEndpoints> endPointConfigSupplier = () -> new KafkaEndpoints() {
+        Supplier<KafkaClusterConfig.KafkaEndpoints> endPointConfigSupplier = () -> new KafkaClusterConfig.KafkaEndpoints() {
             final List<Integer> ports = Utils.preAllocateListeningPorts(clusterConfig.getBrokersNum()).collect(Collectors.toList());
 
             @Override
@@ -118,7 +116,7 @@ public class ContainerBasedKafkaCluster implements Startable, KafkaCluster {
                 return EndpointPair.builder().bind(new Endpoint("0.0.0.0", 9091)).connect(new Endpoint(String.format("broker-%d", brokerId), 9091)).build();
             }
         };
-        Supplier<Endpoint> zookeeperEndpointSupplier = () -> new Endpoint("zookeeper", ContainerBasedKafkaCluster.ZOOKEEPER_PORT);
+        Supplier<KafkaClusterConfig.KafkaEndpoints.Endpoint> zookeeperEndpointSupplier = () -> new KafkaClusterConfig.KafkaEndpoints.Endpoint("zookeeper", ContainerBasedKafkaCluster.ZOOKEEPER_PORT);
         this.brokers = clusterConfig.getBrokerConfigs(endPointConfigSupplier, zookeeperEndpointSupplier).map(holder -> {
             String netAlias = "broker-" + holder.getBrokerNum();
             KafkaContainer kafkaContainer = new KafkaContainer(this.kafkaImage)

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaCluster.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.proxy.testkafkacluster;
+package io.kroxylicious.test.kafkacluster;
 
 import java.util.Map;
 

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaCluster.java
@@ -27,6 +27,11 @@ public interface KafkaCluster extends AutoCloseable {
     String getBootstrapServers();
 
     /**
+     * @return The cluster id for KRaft-based clusters, otherwise null;
+     */
+    String getClusterId();
+
+    /**
      * Gets the kafka configuration for making connections to this cluster as required by the
      * {@link org.apache.kafka.clients.admin.AdminClient}, {@link org.apache.kafka.clients.producer.Producer} etc.
      * Details such the bootstrap and SASL configuration are provided automatically.
@@ -35,4 +40,16 @@ public interface KafkaCluster extends AutoCloseable {
      * @return mutable configuration map
      */
     Map<String, Object> getKafkaClientConfiguration();
+
+    /**
+     * Gets the kafka configuration for making connections to this cluster as required by the
+     * {@link org.apache.kafka.clients.admin.AdminClient}, {@link org.apache.kafka.clients.producer.Producer} etc.
+     * Details such the bootstrap and SASL configuration are provided automatically.
+     * The returned map is guaranteed to be mutable and is unique to the caller.
+     *
+     * @param user The user
+     * @param password The password
+     * @return mutable configuration map
+     */
+    Map<String, Object> getKafkaClientConfiguration(String user, String password);
 }

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaClusterConfig.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaClusterConfig.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.kroxylicious.proxy.testkafkacluster;
+package io.kroxylicious.test.kafkacluster;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,7 +22,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.junit.jupiter.api.TestInfo;
 
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig.KafkaEndpoints.Endpoint;
+import io.kroxylicious.test.kafkacluster.KafkaClusterConfig.KafkaEndpoints.Endpoint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaClusterExecutionMode.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaClusterExecutionMode.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.proxy.testkafkacluster;
+package io.kroxylicious.test.kafkacluster;
 
 public enum KafkaClusterExecutionMode {
     /**

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaClusterFactory.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/KafkaClusterFactory.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.kroxylicious.proxy.testkafkacluster;
+package io.kroxylicious.test.kafkacluster;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/Utils.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/Utils.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.proxy.testkafkacluster;
+package io.kroxylicious.test.kafkacluster;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/BrokerCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/BrokerCluster.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.test.kafkacluster.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.kroxylicious.test.kafkacluster.KafkaCluster;
+
+/**
+ * {@code @BrokerCluster} can be used to annotate a field in a test class or a
+ *  parameter in a lifecycle method or test method of type {@link KafkaCluster}
+ *  that should be resolved into a temporary Kafka cluster.
+ */
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BrokerCluster {
+    /**
+     * @return The number of brokers in the cluster
+     */
+    public int numBrokers() default 1;
+
+}

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/KRaftCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/KRaftCluster.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.test.kafkacluster.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used with {@link BrokerCluster} to specify that a KRaft-based
+ * configuration should be used
+ */
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KRaftCluster {
+    /**
+     * @return The number of KRaft controllers
+     */
+    public int numControllers() default 1;
+}

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/KafkaClusterExtension.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/KafkaClusterExtension.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.test.kafkacluster.extension;
+
+import java.io.File;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+import io.kroxylicious.test.kafkacluster.ContainerBasedKafkaCluster;
+import io.kroxylicious.test.kafkacluster.KafkaCluster;
+import io.kroxylicious.test.kafkacluster.KafkaClusterConfig;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
+import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
+
+public class KafkaClusterExtension implements
+        ParameterResolver, BeforeEachCallback,
+        BeforeAllCallback {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(KafkaClusterExtension.class);
+
+    static class CloseableKafkaCluster implements ExtensionContext.Store.CloseableResource {
+
+        private final KafkaCluster cluster;
+        private final AnnotatedElement sourceElement;
+
+        public CloseableKafkaCluster(AnnotatedElement sourceElement, KafkaCluster cluster) {
+            this.sourceElement = sourceElement;
+            this.cluster = cluster;
+        }
+
+        public KafkaCluster get() {
+            return cluster;
+        }
+
+        @Override
+        public void close() throws Throwable {
+            System.err.println("Stopping cluster for " + sourceElement);
+            cluster.close();
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.isAnnotated(BrokerCluster.class) &&
+                KafkaCluster.class.isAssignableFrom(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        assertSupportedType("parameter", parameterContext.getParameter().getType());
+        return getCluster(parameterContext.getParameter(), null, extensionContext);
+    }
+
+    /**
+     * Perform field injection for non-private, static fields
+     * of type {@link KafkaCluster} or {@link KafkaCluster} that are annotated
+     * with {@link BrokerCluster @BrokerCluster}.
+     */
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        injectStaticFields(context, context.getRequiredTestClass());
+    }
+
+    /**
+     * Perform field injection for non-private, non-static fields (i.e.,
+     * instance fields) of type {@link Path} or {@link File} that are annotated
+     * with {@link TempDir @TempDir}.
+     */
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        context.getRequiredTestInstances().getAllInstances().forEach(instance -> injectInstanceFields(context, instance));
+    }
+
+    private void injectInstanceFields(ExtensionContext context, Object instance) {
+        injectFields(context, instance, instance.getClass(), ReflectionUtils::isNotStatic);
+    }
+
+    private void injectStaticFields(ExtensionContext context, Class<?> testClass) {
+        injectFields(context, null, testClass, ReflectionUtils::isStatic);
+    }
+
+    private void injectFields(ExtensionContext context, Object testInstance, Class<?> testClass, Predicate<Field> predicate) {
+        findAnnotatedFields(testClass, BrokerCluster.class, predicate).forEach(field -> {
+            assertSupportedType("field", field.getType());
+            try {
+                makeAccessible(field).set(testInstance, getCluster(field, field.getType(), context));
+            }
+            catch (Throwable t) {
+                ExceptionUtils.throwAsUncheckedException(t);
+            }
+        });
+    }
+
+    private KafkaCluster getCluster(AnnotatedElement sourceElement, Class<?> type, ExtensionContext extensionContext) {
+
+        ExtensionContext.Namespace namespace = NAMESPACE.append(sourceElement);
+        Object key = sourceElement;
+        KafkaCluster cluster = extensionContext.getStore(namespace)
+                .getOrComputeIfAbsent(key, __ -> createCluster(sourceElement), CloseableKafkaCluster.class)
+                .get();
+        System.err.println("Starting cluster for key " + key);
+        cluster.start();
+        return cluster;
+    }
+
+    private CloseableKafkaCluster createCluster(AnnotatedElement sourceElement) {
+        var broker = sourceElement.getAnnotation(BrokerCluster.class);
+        var builder = KafkaClusterConfig.builder()
+                .brokersNum(broker.numBrokers());
+        if (sourceElement.isAnnotationPresent(KRaftCluster.class)
+                && sourceElement.isAnnotationPresent(ZooKeeperCluster.class)) {
+            throw new ExtensionConfigurationException(
+                    "Either @" + KRaftCluster.class.getSimpleName() + " or " + ZooKeeperCluster.class.getSimpleName() + " can be used, not both");
+        }
+        else if (sourceElement.isAnnotationPresent(KRaftCluster.class)) {
+            var kraft = sourceElement.getAnnotation(KRaftCluster.class);
+            builder.kraftMode(true).kraftControllers(kraft.numControllers());
+        }
+        else if (sourceElement.isAnnotationPresent(ZooKeeperCluster.class)) {
+            builder.kraftMode(false);
+        }
+        else {
+            builder.kraftMode(true).kraftControllers(1);
+        }
+
+        if (sourceElement.isAnnotationPresent(SaslPlainAuth.class)) {
+            var authn = sourceElement.getAnnotation(SaslPlainAuth.class);
+            builder.saslMechanism("PLAIN");
+            builder.users(Arrays.stream(authn.value())
+                    .collect(Collectors.toMap(
+                            SaslPlainAuth.UserPassword::user,
+                            SaslPlainAuth.UserPassword::password)));
+        }
+
+        ContainerBasedKafkaCluster c = new ContainerBasedKafkaCluster(builder.build());
+        return new CloseableKafkaCluster(sourceElement, c);
+    }
+
+    private void assertSupportedType(String target, Class<?> type) {
+        if (type != KafkaCluster.class) {
+            throw new ExtensionConfigurationException("Can only resolve @" + BrokerCluster.class.getSimpleName() + " " + target + " of type "
+                    + KafkaCluster.class + " but was: " + type.getName());
+        }
+    }
+}

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/SaslPlainAuth.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/SaslPlainAuth.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.test.kafkacluster.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used with {@link BrokerCluster} to specify that the cluster
+ * should use SASL PLAIN authentication.
+ */
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SaslPlainAuth {
+
+    /**
+     * @return The configured users, which must be non-empty.
+     */
+    UserPassword[] value();
+
+    @interface UserPassword {
+        /**
+         * @return A user name.
+         */
+        String user();
+
+        /**
+         * @return A password.
+         */
+        String password();
+    }
+}

--- a/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/ZooKeeperCluster.java
+++ b/integrationtests/src/main/java/io/kroxylicious/test/kafkacluster/extension/ZooKeeperCluster.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.test.kafkacluster.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used with {@link BrokerCluster} to specify that a ZooKeeper-based
+ * configuration should be used
+ */
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ZooKeeperCluster {
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KafkaClusterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KafkaClusterIT.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.proxy.testkafkacluster.ContainerBasedKafkaCluster;
-import io.kroxylicious.proxy.testkafkacluster.KafkaCluster;
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig;
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterFactory;
+import io.kroxylicious.test.kafkacluster.ContainerBasedKafkaCluster;
+import io.kroxylicious.test.kafkacluster.KafkaCluster;
+import io.kroxylicious.test.kafkacluster.KafkaClusterConfig;
+import io.kroxylicious.test.kafkacluster.KafkaClusterFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -33,8 +33,8 @@ import org.junit.jupiter.api.TestInfo;
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.internal.filter.ByteBufferTransformation;
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig;
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterFactory;
+import io.kroxylicious.test.kafkacluster.KafkaClusterConfig;
+import io.kroxylicious.test.kafkacluster.KafkaClusterFactory;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integrationtests/src/test/java/io/kroxylicious/test/kafkacluster/KafkaClusterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/test/kafkacluster/KafkaClusterIT.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.kroxylicious.proxy;
+package io.kroxylicious.test.kafkacluster;
 
 import java.time.Duration;
 import java.util.List;
@@ -26,11 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.kroxylicious.test.kafkacluster.ContainerBasedKafkaCluster;
-import io.kroxylicious.test.kafkacluster.KafkaCluster;
-import io.kroxylicious.test.kafkacluster.KafkaClusterConfig;
-import io.kroxylicious.test.kafkacluster.KafkaClusterFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;

--- a/integrationtests/src/test/java/io/kroxylicious/test/kafkacluster/extension/KafkaClusterExtensionTest.java
+++ b/integrationtests/src/test/java/io/kroxylicious/test/kafkacluster/extension/KafkaClusterExtensionTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.test.kafkacluster.extension;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.kroxylicious.test.kafkacluster.ContainerBasedKafkaCluster;
+import io.kroxylicious.test.kafkacluster.KafkaCluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(KafkaClusterExtension.class)
+public class KafkaClusterExtensionTest {
+
+    @BrokerCluster(numBrokers = 1)
+    static KafkaCluster staticCluster;
+
+    @BrokerCluster(numBrokers = 1)
+    KafkaCluster instanceCluster;
+
+    @Test
+    public void testKafkaClusterStaticField()
+            throws ExecutionException, InterruptedException {
+        var dc = assertCluster(staticCluster.getKafkaClientConfiguration());
+        assertEquals(1, dc.nodes().get().size());
+        assertEquals(staticCluster.getClusterId(), dc.clusterId().get());
+        var cbc = assertInstanceOf(ContainerBasedKafkaCluster.class, staticCluster);
+    }
+
+    @Test
+    public void testKafkaClusterInstanceField()
+            throws ExecutionException, InterruptedException {
+        var dc = assertCluster(instanceCluster.getKafkaClientConfiguration());
+        assertEquals(1, dc.nodes().get().size());
+        assertEquals(instanceCluster.getClusterId(), dc.clusterId().get());
+        var cbc = assertInstanceOf(ContainerBasedKafkaCluster.class, instanceCluster);
+    }
+
+    @Test
+    public void testKafkaClusterParameter(
+                                          @BrokerCluster(numBrokers = 2) KafkaCluster cluster)
+            throws ExecutionException, InterruptedException {
+        var dc = assertCluster(cluster.getKafkaClientConfiguration());
+        assertEquals(2, dc.nodes().get().size());
+        assertEquals(cluster.getClusterId(), dc.clusterId().get());
+        var cbc = assertInstanceOf(ContainerBasedKafkaCluster.class, cluster);
+    }
+
+    @Test
+    public void testTwoKafkaClusterParameter(
+                                             @BrokerCluster(numBrokers = 1) KafkaCluster cluster1,
+                                             @BrokerCluster(numBrokers = 2) KafkaCluster cluster2)
+            throws ExecutionException, InterruptedException {
+        assertNotEquals(cluster1.getClusterId(), cluster2.getClusterId());
+        var dc1 = assertCluster(cluster1.getKafkaClientConfiguration());
+        assertEquals(1, dc1.nodes().get().size());
+        assertEquals(cluster1.getClusterId(), dc1.clusterId().get());
+        var dc2 = assertCluster(cluster2.getKafkaClientConfiguration());
+        assertEquals(2, dc2.nodes().get().size());
+        assertEquals(cluster2.getClusterId(), dc2.clusterId().get());
+    }
+
+    @Test
+    public void testZkBasedKafkaCluster(
+                                        @BrokerCluster @ZooKeeperCluster KafkaCluster cluster)
+            throws ExecutionException, InterruptedException {
+        var dc = assertCluster(cluster.getKafkaClientConfiguration());
+        assertEquals(1, dc.nodes().get().size());
+        assertNull(cluster.getClusterId(),
+                "KafkaCluster.getClusterId() should be null for ZK-based clusters");
+    }
+
+    @Test
+    public void testKraftBasedKafkaCluster(
+                                           @BrokerCluster @KRaftCluster KafkaCluster cluster)
+            throws ExecutionException, InterruptedException {
+        var dc = assertCluster(cluster.getKafkaClientConfiguration());
+        assertEquals(1, dc.nodes().get().size());
+    }
+
+    @Test
+    public void testSaslPlainCluster(
+                                     @BrokerCluster @SaslPlainAuth({
+                                             @SaslPlainAuth.UserPassword(user = "alice", password = "foo"),
+                                             @SaslPlainAuth.UserPassword(user = "bob", password = "bar")
+                                     }) KafkaCluster cluster)
+            throws ExecutionException, InterruptedException {
+        var dc = assertCluster(cluster.getKafkaClientConfiguration("alice", "foo"));
+        assertEquals(1, dc.nodes().get().size());
+        assertEquals(cluster.getClusterId(), dc.clusterId().get());
+
+        dc = assertCluster(cluster.getKafkaClientConfiguration("bob", "bar"));
+        assertEquals(cluster.getClusterId(), dc.clusterId().get());
+
+        var ee = assertThrows(ExecutionException.class, () -> assertCluster(cluster.getKafkaClientConfiguration("bob", "baz")),
+                "Expect bad password to throw");
+        assertInstanceOf(SaslAuthenticationException.class, ee.getCause());
+
+        ee = assertThrows(ExecutionException.class, () -> assertCluster(cluster.getKafkaClientConfiguration("eve", "quux")),
+                "Expect unknown user to throw");
+        assertInstanceOf(SaslAuthenticationException.class, ee.getCause());
+    }
+
+    private static DescribeClusterResult assertCluster(Map<String, Object> adminConfig) throws InterruptedException, ExecutionException {
+        try (var admin = Admin.create(adminConfig)) {
+            DescribeClusterResult describeClusterResult = admin.describeCluster();
+            describeClusterResult.controller().get();
+            return describeClusterResult;
+        }
+    }
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -62,7 +62,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         if (logFrames) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));
         }
-        
+
         pipeline.addLast("frontendHandler", new KafkaProxyFrontendHandler(remoteHost,
                 remotePort,
                 correlation,


### PR DESCRIPTION
This PR does  one significant thing

* Add support for a Junit5 extension that allows declarative test clusters via annotation

It also does  a few minor things:

* Add method `getClusterId` to `KafkaCluster`, which can be useful in certain contexts.
* Add method `getKafkaClientConfiguration(String user, String password)` to `KafkaCluster`. This allows for more convenient testing with multiple SASL users when those used are declared by annotation, including writing tests for bad credentials/unknown users against test `KafkaClusters` with some users defined.
* Moves the package for the test infrastructure, because it doesn't depend on the proxy work in any way.

Examples for how to declare test clusters are in the test for the extension. The API is such as it is to minimise the need for changes in future when support for ZK mode gets removed from Kafka. E.g. the `@ZooKeeperCluster` annotation can be deprecated and removed without affecting tests which don't explicitly depend on ZK. 

I'm creating a _draft_ PR because I don't actually want to merge this in its current form. I think this is useful for other projects (in a similar way to the Debezium Kafka cluster test code). So I'd like to factor both the junit extension and the `KafkaCluster` infrastructure into its own distinct repo under the kroxylicious org. That would allow us to do a release of this test infra, allowing other projects to use it while we work towards a release of kproxy.