### PR TITLE
Added support for TLS in kafka cluster config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target/
 .apt_generated/
 .apt_generated_tests/
 bin/
+certs/
 
 # IntelliJ IDEA specific
 .idea/

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testkafkacluster/KafkaClusterConfig.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testkafkacluster/KafkaClusterConfig.java
@@ -5,17 +5,6 @@
  */
 package io.kroxylicious.proxy.testkafkacluster;
 
-import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig.KafkaEndpoints.Endpoint;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Singular;
-import lombok.ToString;
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.junit.jupiter.api.TestInfo;
-
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.*;
@@ -23,6 +12,18 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.junit.jupiter.api.TestInfo;
+
+import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig.KafkaEndpoints.Endpoint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
 
 @Builder(toBuilder = true)
 @Getter
@@ -135,12 +136,13 @@ public class KafkaClusterConfig {
                 server.put(String.format("listener.name.%s.plain.sasl.jaas.config", "EXTERNAL".toLowerCase()), plainModuleConfig);
             }
 
-            if (securityProtocol.equals(SecurityProtocol.SSL.toString()) || securityProtocol.equals(SecurityProtocol.SASL_SSL.toString())) {
+            if (securityProtocol != null && securityProtocol.contains("SSL")) {
                 KeytoolCertificateGenerator keytoolCertificateGenerator = new KeytoolCertificateGenerator();
                 try {
-                    keytoolCertificateGenerator.generateSelfSignedCertificateEntry("test@redhat.com", clientEndpoint.getConnect().getHost()
-                            , "KI", "RedHat", null, null, "US");
-                } catch (GeneralSecurityException | IOException e) {
+                    keytoolCertificateGenerator.generateSelfSignedCertificateEntry("test@redhat.com", clientEndpoint.getConnect().getHost(), "KI", "RedHat", null, null,
+                            "US");
+                }
+                catch (GeneralSecurityException | IOException e) {
                     throw new RuntimeException(e);
                 }
                 server.put("ssl.client.auth", "required");

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testkafkacluster/KeytoolCertificateGenerator.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testkafkacluster/KeytoolCertificateGenerator.java
@@ -1,0 +1,114 @@
+package io.kroxylicious.proxy.testkafkacluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class KeytoolCertificateGenerator {
+    private static String password;
+    private static final String certsDirectory = "certs";
+    private static final Path certFilePath = Paths.get(certsDirectory, "kafka.jks");
+
+    private static final Logger log = LoggerFactory.getLogger(KeytoolCertificateGenerator.class.getName());
+
+    public static String getCertLocation() {
+        return certFilePath.toAbsolutePath().toString();
+    }
+
+    public static String getPassword() {
+        if (password == null) {
+            password = UUID.randomUUID().toString().replace("-", "");
+        }
+        return password;
+    }
+
+    public boolean canGenerateWildcardSAN() {
+        return Runtime.version().feature() >= 17;
+    }
+
+    public void generateSelfSignedCertificateEntry(String email, String domain, String organizationUnit,
+                                                               String organization, String city, String state,
+                                                               String country)
+            throws GeneralSecurityException, IOException {
+
+        Path certsPath = Paths.get(certsDirectory);
+        if (Files.notExists(certsPath)) {
+            Files.createDirectory(certsPath);
+        }
+
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        if (certFilePath.toFile().exists()) {
+            keyStore.load(new FileInputStream(certFilePath.toFile()), getPassword().toCharArray());
+
+            if (keyStore.containsAlias(domain)) {
+                keyStore.deleteEntry(domain);
+                keyStore.store(new FileOutputStream(certFilePath.toFile()), getPassword().toCharArray());
+            }
+        }
+
+        final List<String> commandParameters = new ArrayList<>(List.of("keytool", "-genkey"));
+        commandParameters.addAll(List.of("-alias", domain));
+        commandParameters.addAll(List.of("-keyalg", "RSA"));
+        commandParameters.addAll(List.of("-keysize", "2048"));
+        commandParameters.addAll(List.of("-sigalg", "SHA256withRSA"));
+        commandParameters.addAll(List.of("-storetype", "JKS"));
+        commandParameters.addAll(List.of("-keystore", certFilePath.toString()));
+        commandParameters.addAll(List.of("-storepass", getPassword()));
+        commandParameters.addAll(List.of("-keypass", getPassword()));
+        commandParameters.addAll(
+                List.of("-dname", getDomainName(email, domain, organizationUnit, organization, city, state, country)));
+        commandParameters.addAll(List.of("-validity", "365"));
+        commandParameters.addAll(List.of("-deststoretype", "pkcs12"));
+        commandParameters.addAll(List.of("-storetype", "JKS"));
+        if (canGenerateWildcardSAN() && !isWildcardDomain(domain)) {
+            commandParameters.addAll(getSAN(domain));
+        }
+        ProcessBuilder keytool = new ProcessBuilder().command(commandParameters);
+
+        final Process process = keytool.start();
+        try {
+            process.waitFor();
+        } catch (InterruptedException e) {
+            throw new IOException("Keytool execution error");
+        }
+
+        log.info("Generating certificate using `keytool` using command: " + process.info() + ", parameters: " +
+                        commandParameters);
+
+        if (process.exitValue() > 0) {
+            final String processError = (new BufferedReader(new InputStreamReader(process.getErrorStream()))).lines()
+                    .collect(Collectors.joining(" \\ "));
+            final String processOutput = (new BufferedReader(new InputStreamReader(process.getInputStream()))).lines()
+                    .collect(Collectors.joining(" \\ "));
+            log.warn("Error generating certificate, error output: " + processError + ", normal output: " +
+                    processOutput + ", commandline parameters: " + commandParameters);
+            throw new IOException(
+                    "Keytool execution error: '" + processError + "', output: '" + processOutput + "'" + ", commandline parameters: " + commandParameters);
+        }
+    }
+
+    private boolean isWildcardDomain(String domain) {
+        return domain.startsWith("*.");
+    }
+
+    private String getDomainName(String email, String domain, String organizationUnit, String organization, String city,
+                                 String state, String country) {
+        // keytool doesn't allow for a domain with wildcard in SAN extension, so it has to go directly to CN
+        return "CN=" + domain + ", OU=" + organizationUnit + ", O=" + organization + ", L=" + city + ", ST=" + state +
+                ", C=" + country + ", EMAILADDRESS=" + email;
+    }
+
+    private List<String> getSAN(String domain) {
+        return List.of("-ext", "SAN=dns:" + domain);
+    }
+}

--- a/integrationtests/src/main/java/io/kroxylicious/proxy/testkafkacluster/KeytoolCertificateGenerator.java
+++ b/integrationtests/src/main/java/io/kroxylicious/proxy/testkafkacluster/KeytoolCertificateGenerator.java
@@ -1,7 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.kroxylicious.proxy.testkafkacluster;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -13,6 +15,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KeytoolCertificateGenerator {
     private static String password;
@@ -37,8 +42,8 @@ public class KeytoolCertificateGenerator {
     }
 
     public void generateSelfSignedCertificateEntry(String email, String domain, String organizationUnit,
-                                                               String organization, String city, String state,
-                                                               String country)
+                                                   String organization, String city, String state,
+                                                   String country)
             throws GeneralSecurityException, IOException {
 
         Path certsPath = Paths.get(certsDirectory);
@@ -78,12 +83,13 @@ public class KeytoolCertificateGenerator {
         final Process process = keytool.start();
         try {
             process.waitFor();
-        } catch (InterruptedException e) {
+        }
+        catch (InterruptedException e) {
             throw new IOException("Keytool execution error");
         }
 
         log.info("Generating certificate using `keytool` using command: " + process.info() + ", parameters: " +
-                        commandParameters);
+                commandParameters);
 
         if (process.exitValue() > 0) {
             final String processError = (new BufferedReader(new InputStreamReader(process.getErrorStream()))).lines()

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KafkaClusterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KafkaClusterIT.java
@@ -5,7 +5,15 @@
  */
 package io.kroxylicious.proxy;
 
-import io.kroxylicious.proxy.testkafkacluster.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -24,14 +32,7 @@ import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import io.kroxylicious.proxy.testkafkacluster.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -47,7 +48,10 @@ public class KafkaClusterIT {
 
     @Test
     public void kafkaClusterKraftMode() throws Exception {
-        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).kraftMode(true).build())) {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .kraftMode(true)
+                .build())) {
             cluster.start();
             verifyRecordRoundTrip(1, cluster);
         }
@@ -55,7 +59,10 @@ public class KafkaClusterIT {
 
     @Test
     public void kafkaClusterZookeeperMode() throws Exception {
-        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).kraftMode(false).build())) {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .kraftMode(false)
+                .build())) {
             cluster.start();
             verifyRecordRoundTrip(1, cluster);
         }
@@ -64,7 +71,11 @@ public class KafkaClusterIT {
     @Test
     public void kafkaTwoNodeClusterKraftMode() throws Exception {
         int brokersNum = 2;
-        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).brokersNum(brokersNum).kraftMode(true).build())) {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .brokersNum(brokersNum)
+                .kraftMode(true)
+                .build())) {
             assumeTrue(cluster instanceof ContainerBasedKafkaCluster, "KAFKA-14287: kraft timing out on shutdown in multinode case");
             cluster.start();
             verifyRecordRoundTrip(brokersNum, cluster);
@@ -74,7 +85,11 @@ public class KafkaClusterIT {
     @Test
     public void kafkaTwoNodeClusterZookeeperMode() throws Exception {
         int brokersNum = 2;
-        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).brokersNum(brokersNum).kraftMode(false).build())) {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .brokersNum(brokersNum)
+                .kraftMode(false)
+                .build())) {
             cluster.start();
             verifyRecordRoundTrip(brokersNum, cluster);
         }
@@ -82,8 +97,13 @@ public class KafkaClusterIT {
 
     @Test
     public void kafkaClusterKraftModeWithAuth() throws Exception {
-        try (var cluster = KafkaClusterFactory.create(
-                KafkaClusterConfig.builder().kraftMode(true).testInfo(testInfo).saslMechanism("PLAIN").user("guest", "guest").build())) {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .kraftMode(true)
+                .testInfo(testInfo)
+                .securityProtocol("SASL_PLAINTEXT")
+                .saslMechanism("PLAIN")
+                .user("guest", "guest")
+                .build())) {
             cluster.start();
             verifyRecordRoundTrip(1, cluster);
         }
@@ -91,8 +111,13 @@ public class KafkaClusterIT {
 
     @Test
     public void kafkaClusterZookeeperModeWithAuth() throws Exception {
-        try (var cluster = KafkaClusterFactory.create(
-                KafkaClusterConfig.builder().testInfo(testInfo).kraftMode(false).saslMechanism("PLAIN").user("guest", "guest").build())) {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .kraftMode(false)
+                .securityProtocol("SASL_PLAINTEXT")
+                .saslMechanism("PLAIN")
+                .user("guest", "guest")
+                .build())) {
             cluster.start();
             verifyRecordRoundTrip(1, cluster);
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -62,7 +62,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         if (logFrames) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));
         }
-        
+
         pipeline.addLast("frontendHandler", new KafkaProxyFrontendHandler(remoteHost,
                 remotePort,
                 correlation,


### PR DESCRIPTION
* Added configuration for securityProtocol SSL and SASL_SSL
* JKS file for server and client generated dynamically each test run. Using `SAN` extension remediates the DNS name problem.
* Added new integration test cases for different combinations: 
  * Kraft mode --> SASL_SSL/PLAIN
  * Kraft mode --> SSL
  * Zookeeper mode --> SASL_SSL/PLAIN
  * Zookeeper mode --> SSL

Related to issue #85 